### PR TITLE
Make prop types more specific

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "es6": true
   },
   "rules": {
+    "arrow-parens": [0],
     "quotes": [1, "double"],
     "eol-last": [0],
     "no-mixed-requires": [0],
@@ -27,7 +28,11 @@
     "semi": [1, "always"],
     "no-use-before-define": [2],
     "no-undef": [2],
-    "no-param-reassign": [0]
+    "no-param-reassign": [0],
+    "react/forbid-prop-types": [2],
+    "react/no-danger": [0],
+    "react/no-unused-prop-types": [2, { skipShapeProps: true }],
+    "jsx-a11y/no-static-element-interactions": [1]
   },
   "plugins": [
     "react"

--- a/src/components/amenities/index.jsx
+++ b/src/components/amenities/index.jsx
@@ -149,7 +149,7 @@ Amenities.propTypes = {
   /**
    * Data
    */
-  items: React.PropTypes.array.isRequired,
+  items: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
 
   /**
    * Number of columns to span

--- a/src/components/availability/index.jsx
+++ b/src/components/availability/index.jsx
@@ -93,7 +93,7 @@ Availability.propTypes = {
   /**
    * Price
    */
-  price: React.PropTypes.object.isRequired,
+  price: React.PropTypes.shape(Price.propTypes).isRequired,
 
   /**
    * Availability url to send to external resource

--- a/src/components/breadcrumbs/index.jsx
+++ b/src/components/breadcrumbs/index.jsx
@@ -76,7 +76,13 @@ Breadcrumbs.propTypes = {
   /**
    * An array of links for the navigation
    */
-  links: React.PropTypes.array.isRequired,
+  links: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      title: React.PropTypes.string,
+      href: React.PropTypes.string,
+      type: React.PropTypes.string,
+    }),
+  ).isRequired,
 };
 
 Breadcrumbs.defaultProps = {

--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -239,7 +239,10 @@ Button.propTypes = {
   /**
    * Special styles passed in props
    */
-  customStyles: React.PropTypes.object,
+  customStyles: React.PropTypes.objectOf(
+    React.PropTypes.string,
+    React.PropTypes.number,
+  ),
 
   /**
    * Use a border

--- a/src/components/callout/index.jsx
+++ b/src/components/callout/index.jsx
@@ -220,7 +220,7 @@ Callout.propTypes = {
 
   image: React.PropTypes.string.isRequired,
 
-  price: React.PropTypes.object,
+  price: React.PropTypes.shape(Price.propTypes),
 
   description: React.PropTypes.string,
 

--- a/src/components/contentHeader/index.jsx
+++ b/src/components/contentHeader/index.jsx
@@ -77,7 +77,7 @@ ContentHeader.propTypes = {
   /**
    * Options for Heading component
    */
-  heading: React.PropTypes.object.isRequired,
+  heading: React.PropTypes.shape(Heading.propTypes).isRequired,
 
   /**
    * Adds a border to the header
@@ -91,7 +91,7 @@ ContentHeader.propTypes = {
   /**
    * Options for MoreLink component
    */
-  moreLink: React.PropTypes.object,
+  moreLink: React.PropTypes.shape(MoreLink.propTypes),
 };
 
 ContentHeader.defaultProps = {

--- a/src/components/contentSectionList/index.jsx
+++ b/src/components/contentSectionList/index.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import font from "../../utils/font";
 import ContentHeader from "../contentHeader";
+import Heading from "../heading";
 
 const styles = {
   list: {
@@ -41,14 +42,22 @@ ContentSectionList.propTypes = {
   /**
    * Props for ContentHeader
    */
-  header: React.PropTypes.object.isRequired,
+  header: React.PropTypes.shape({
+    title: React.PropTypes.string,
+    heading: React.PropTypes.shape(Heading.propTypes),
+    border: React.PropTypes.oneOf([
+      "",
+      "top",
+      "bottom",
+    ]),
+  }).isRequired,
 
   /**
    * List item(s) to display
    */
   listItems: React.PropTypes.oneOfType([
     React.PropTypes.string,
-    React.PropTypes.array,
+    React.PropTypes.arrayOf(React.PropTypes.string),
   ]).isRequired,
 };
 

--- a/src/components/dropdown/index.jsx
+++ b/src/components/dropdown/index.jsx
@@ -65,7 +65,7 @@ Dropdown.propTypes = {
   /**
    * An array of options for the select element
    */
-  options: React.PropTypes.array.isRequired,
+  options: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
 
   /**
    * A value from the options array that will be selected initially

--- a/src/components/flyout/index.jsx
+++ b/src/components/flyout/index.jsx
@@ -286,7 +286,10 @@ Flyout.propTypes = {
   /**
    * Styles for positioning, etc.
    */
-  style: React.PropTypes.object,
+  style: React.PropTypes.objectOf(
+    React.PropTypes.string,
+    React.PropTypes.number,
+  ),
 };
 
 Flyout.defaultProps = {

--- a/src/components/form/checkbox.jsx
+++ b/src/components/form/checkbox.jsx
@@ -203,7 +203,10 @@ Checkbox.propTypes = {
   /**
    * CSS styles to append to component's styles
    */
-  style: React.PropTypes.object,
+  style: React.PropTypes.objectOf(
+    React.PropTypes.string,
+    React.PropTypes.number,
+  ),
 };
 
 Checkbox.defaultProps = {

--- a/src/components/form/range.jsx
+++ b/src/components/form/range.jsx
@@ -164,7 +164,7 @@ Range.propTypes = {
   /**
    * Initial values for the slider
    */
-  defaultValue: React.PropTypes.array.isRequired,
+  defaultValue: React.PropTypes.arrayOf(React.PropTypes.number).isRequired,
 
   /**
    * Minimum value for slider

--- a/src/components/form/select.jsx
+++ b/src/components/form/select.jsx
@@ -57,7 +57,7 @@ function Select({
 Select.propTypes = {
   id: React.PropTypes.string.isRequired,
 
-  options: React.PropTypes.array.isRequired,
+  options: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
 
   label: React.PropTypes.string.isRequired,
 
@@ -87,7 +87,10 @@ Select.propTypes = {
    */
   noBorder: React.PropTypes.bool,
 
-  style: React.PropTypes.object,
+  style: React.PropTypes.objectOf(
+    React.PropTypes.string,
+    React.PropTypes.number,
+  ),
 };
 
 Select.defaultProps = {

--- a/src/components/heading/index.jsx
+++ b/src/components/heading/index.jsx
@@ -218,8 +218,8 @@ Heading.propTypes = {
    * Override styles
    */
   override: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.array,
+    React.PropTypes.objectOf(React.PropTypes.string, React.PropTypes.number),
+    React.PropTypes.arrayOf(React.PropTypes.object),
   ]),
 };
 

--- a/src/components/icon/index.jsx
+++ b/src/components/icon/index.jsx
@@ -149,7 +149,10 @@ Icon.propTypes = {
   /**
    * Override width and height
    */
-  dimensions: React.PropTypes.object,
+  dimensions: React.PropTypes.shape({
+    width: React.PropTypes.number,
+    height: React.PropTypes.number,
+  }),
 
   /**
    * Name of CSS animation to apply
@@ -159,7 +162,10 @@ Icon.propTypes = {
   /**
    * Object to apply additional CSS styles
    */
-  style: React.PropTypes.object,
+  style: React.PropTypes.objectOf(
+    React.PropTypes.string,
+    React.PropTypes.number,
+  ),
 };
 
 Icon.defaultProps = {

--- a/src/components/imageHero/index.jsx
+++ b/src/components/imageHero/index.jsx
@@ -11,7 +11,7 @@ const propTypes = {
   /**
    * Width and height of the image
    */
-  imageSize: PropTypes.array.isRequired,
+  imageSize: PropTypes.arrayOf(React.PropTypes.number).isRequired,
 };
 
 const defaultProps = {

--- a/src/components/listItem/index.jsx
+++ b/src/components/listItem/index.jsx
@@ -336,17 +336,30 @@ ListItem.propTypes = {
   /**
    * The place data for the POI; required keys are name and type
    */
-  place: React.PropTypes.object.isRequired,
+  place: React.PropTypes.shape({
+    name: React.PropTypes.string,
+    type: React.PropTypes.string,
+  }).isRequired,
 
   /**
    * Image src for the POI; required keys are path and orientation
    */
-  image: React.PropTypes.object,
+  image: React.PropTypes.shape({
+    path: React.PropTypes.string,
+    orientation: React.PropTypes.oneOf([
+      "",
+      "portrait",
+      "landscape",
+    ]),
+  }),
 
   /**
    * Link to display under image; required keys are title and url
    */
-  link: React.PropTypes.object,
+  link: React.PropTypes.shape({
+    title: React.PropTypes.string,
+    url: React.PropTypes.string,
+  }),
 
   /**
    * Description for POI

--- a/src/components/listItemBookable/index.jsx
+++ b/src/components/listItemBookable/index.jsx
@@ -539,25 +539,38 @@ ListItemBookable.propTypes = {
   /**
    * The place data for the POI; required keys are name and type
    */
-  place: React.PropTypes.object.isRequired,
+  place: React.PropTypes.shape({
+    name: React.PropTypes.string,
+    type: React.PropTypes.string,
+  }).isRequired,
 
   /**
    * Price object for the POI; requires amount and rate keys
    * key: price_string
    * partner-activities key: minimum_price.formatted_amount
    */
-  price: React.PropTypes.object,
+  price: React.PropTypes.shape({
+    amount: React.PropTypes.number,
+    rate: React.PropTypes.string,
+  }),
 
   /**
    * A short list of features; limited to three
    */
-  features: React.PropTypes.array,
+  features: React.PropTypes.arrayOf(React.PropTypes.string),
 
   /**
    * Image src for the POI; required keys are path and orientation
    * partner-activities key: links.image
    */
-  image: React.PropTypes.object,
+  image: React.PropTypes.shape({
+    path: React.PropTypes.string,
+    orientation: React.PropTypes.oneOf([
+      "",
+      "portrait",
+      "landscape",
+    ]),
+  }),
 
   /**
    * Description for POI

--- a/src/components/location/index.jsx
+++ b/src/components/location/index.jsx
@@ -127,9 +127,7 @@ Location.propTypes = {
   /**
    * An array of latitude and longitude coordinates; used in the Google URL
    */
-  coordinates: React.PropTypes.arrayOf(
-    React.PropTypes.number,
-  ).isRequired,
+  coordinates: React.PropTypes.arrayOf(React.PropTypes.number).isRequired,
 
   /**
    * Should mobile-specific styles and props be used

--- a/src/components/moreLink/index.jsx
+++ b/src/components/moreLink/index.jsx
@@ -106,7 +106,10 @@ MoreLink.propTypes = {
   /**
    * Object to add override or positioning styles
    */
-  style: React.PropTypes.object,
+  style: React.PropTypes.objectOf(
+    React.PropTypes.string,
+    React.PropTypes.number,
+  ),
 };
 
 MoreLink.defaultProps = {

--- a/src/components/narrative/index.jsx
+++ b/src/components/narrative/index.jsx
@@ -129,7 +129,12 @@ Narrative.propTypes = {
   /**
    * Author object
    */
-  author: React.PropTypes.object,
+  author: React.PropTypes.shape({
+    name: React.PropTypes.string,
+    title: React.PropTypes.string,
+    avatar: React.PropTypes.string,
+    url: React.PropTypes.string,
+  }),
 };
 
 Narrative.defaultProps = {

--- a/src/components/numberList/index.jsx
+++ b/src/components/numberList/index.jsx
@@ -107,7 +107,7 @@ NumberList.propTypes = {
   /**
    * An array of items to list
    */
-  list: React.PropTypes.array.isRequired,
+  list: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
 };
 
 NumberList.defaultProps = {

--- a/src/components/placeholder/index.jsx
+++ b/src/components/placeholder/index.jsx
@@ -102,8 +102,8 @@ Placeholder.propTypes = {
    * Style object
    */
   style: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
+    React.PropTypes.arrayOf(React.PropTypes.object),
+    React.PropTypes.objectOf(React.PropTypes.string, React.PropTypes.number),
   ]),
 };
 

--- a/src/components/relatedTour/index.jsx
+++ b/src/components/relatedTour/index.jsx
@@ -211,7 +211,10 @@ RelatedTour.propTypes = {
   /**
    * The price of the tour, containing currency and amount
    */
-  price: React.PropTypes.object.isRequired,
+  price: React.PropTypes.shape({
+    currency: React.PropTypes.string,
+    amount: React.PropTypes.number,
+  }).isRequired,
 
   /**
    * The length of the trip, usually in days i.e., "14 days"

--- a/src/components/tagList/index.jsx
+++ b/src/components/tagList/index.jsx
@@ -61,7 +61,7 @@ TagList.propTypes = {
   /**
    * An array of tags to display
    */
-  tags: React.PropTypes.array.isRequired,
+  tags: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
 
   /**
    * Maximum number of rows of tags to display

--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -121,7 +121,7 @@ Toolbar.propTypes = {
    */
   directions: React.PropTypes.oneOfType([
     React.PropTypes.string,
-    React.PropTypes.array,
+    React.PropTypes.arrayOf(React.PropTypes.string, React.PropTypes.number),
   ]),
 };
 

--- a/src/components/tooltip/index.jsx
+++ b/src/components/tooltip/index.jsx
@@ -21,7 +21,7 @@ const propTypes = {
   /**
    * Props object for Flyout component
    */
-  flyout: PropTypes.object.isRequired,
+  flyout: PropTypes.shape(Flyout.propTypes).isRequired,
 
   /**
    * Content to display with tooltip


### PR DESCRIPTION
This PR replaces vague prop types `React.PropTypes.array` and `React.PropTypes.object` with `React.PropTypes.arrayOf`, `React.PropTypes.objectOf` and `React.PropTypes.shape`.

It also updates the eslint config to throw errors if any of the vague prop types are used.