### PR TITLE
Install, configure Storybook for component development

### DIFF
--- a/.storybook/common.css
+++ b/.storybook/common.css
@@ -1,0 +1,27 @@
+html {
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+  text-rendering: optimizeLegibility;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+/*body {
+  color: #3b444f;
+  font-family: "Benton Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  font-size: 1.8em;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.5;
+  position: relative;
+}*/
+
+/*a {
+  color: #297cbb;
+  text-decoration: none;
+}*/

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,8 @@
+import { configure } from "@kadira/storybook";
+import "./common.css";
+
+function loadStories() {
+  require("../stories");
+}
+
+configure(loadStories, module);

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](https://travis-ci.org/lonelyplanet/backpack-ui.svg?branch=master)
 
 ### backpack-ui
-Every adventurer needs a set of tools to take along the way! Backpack is the Lonely Planet toolset that we use to build front end 
+Every adventurer needs a set of tools to take along the way! Backpack is the Lonely Planet toolset that we use to build front end
 apps.
 
 #### Installation
@@ -14,4 +14,24 @@ npm install backpack-ui --save
 
 ```js
 import { Button } from "backpack-ui";
+```
+
+#### Develop components with Storybook
+
+```shell
+npm run storybook
+```
+
+Open http://localhost:6006/ in your favorite web browser.
+
+Then import your component(s) into stories/index.jsx and render them like so:
+
+```js
+storiesOf("Some component name", module)
+  .add("Default", () => (
+    <ComponentName />
+  ))
+  .add("Some variation", () => (
+    <ComponentName prop="value" />
+  ));
 ```

--- a/package.json
+++ b/package.json
@@ -7,11 +7,14 @@
     "test": "NODE_ENV=test mocha --reporter spec --compilers js:babel-register --recursive spec/",
     "build": "rm -rf dist && mkdir -p dist/components && babel -d dist src",
     "ci": "rm -rf dist && mkdir -p dist/components && babel --watch -d dist src",
-    "test:ci": "NODE_ENV=test mocha --reporter spec --compilers js:babel-register --watch --recursive spec/"
+    "test:ci": "NODE_ENV=test mocha --reporter spec --compilers js:babel-register --watch --recursive spec/",
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook"
   },
   "author": "Lonely Planet",
   "license": "ISC",
   "dependencies": {
+    "@kadira/storybook": "^2.21.0",
     "chai": "^3.5.0",
     "classnames": "^2.2.5",
     "color": "^0.11.3",

--- a/stories/Colors.jsx
+++ b/stories/Colors.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import styles from "./styles.json";
+import { color } from "../settings.json";
+
+function Colors() {
+  const colors = [];
+
+  Object.keys(color).forEach((name) => {
+    if (color[name]) {
+      const light = color[name].startsWith("d", 1) ||
+        color[name].startsWith("e", 1) ||
+        color[name].startsWith("f", 1);
+
+      colors.push(
+        <div style={{ marginBottom: "5px", marginTop: "5px" }}>
+          <div
+            style={{
+              backgroundColor: color[name],
+              color: !light && "#fff",
+              display: "inline-block",
+              height: "30px",
+              marginRight: "10px",
+              width: "30px",
+            }}
+          />
+          <pre
+            style={{
+              display: "inline-block",
+              fontSize: "14px",
+              lineHeight: "30px",
+            }}
+          >
+            <span
+              style={{
+                display: "inline-block",
+                width: "90px",
+              }}
+            >
+              <span style={{ userSelect: "none" }}>{color[name]}</span>
+            </span><span>{name}</span>
+          </pre>
+        </div>
+      );
+    }
+  });
+
+  return (
+    <div style={styles.main}>
+      <h1>Colors</h1>
+
+      <ul
+        style={{
+          display: "inline-block",
+          listStyle: "none",
+          margin: 0,
+          padding: 0,
+          textAlign: "left",
+        }}
+      >
+        {colors.map((el, i) => (
+          <li key={i} style={{ borderTop: `1px solid ${color.gray}` }}>{el}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default Colors;

--- a/stories/data.json
+++ b/stories/data.json
@@ -1,0 +1,256 @@
+{
+  "amenities": {
+    "singleList": [
+      "149 guestrooms",
+      "2 restaurants",
+      "Full-service spa",
+      "Breakfast available",
+      "Health club",
+      "Valet parking",
+      "Business center",
+      "Airport shuttle",
+      "In-room childcare",
+      "24-hour front desk",
+      "Air conditioning",
+      "Daily housekeeping"
+    ],
+    "groupedList": [
+      {
+        "title": "Pets",
+        "items": [
+          "Pets are allowed. Charges may apply."
+        ]
+      },
+      {
+        "title": "Activities",
+        "items": [
+          "Sauna",
+          "Fitness Center",
+          "Spa",
+          "Massage"
+        ]
+      },
+      {
+        "title": "Food & Drink",
+        "items": [
+          "Bar",
+          "Breakfast in the Room",
+          "Restaurant with Dining Menu"
+        ]
+      },
+      {
+        "title": "Internet",
+        "items": [
+          "Free! WiFi is available in the hotel rooms and is free of charge."
+        ]
+      },
+      {
+        "title": "Services",
+        "items": [
+          "Room Service",
+          "Car Rental",
+          "Airport Shuttle (surcharge)",
+          "24-Hour Front Desk",
+          "Express Check-in/Check-out",
+          "Currency Exchange",
+          "Ticket Service",
+          "Baggage Storage",
+          "Concierge Service",
+          "Babysitting/Child Services",
+          "Laundry",
+          "Dry Cleaning",
+          "Ironing Service",
+          "Shoeshine",
+          "Daily Housekeeping",
+          "Meeting/Banquet Facilities",
+          "Business Center",
+          "Fax/Photocopying",
+          "VIP Room Facilities"
+        ]
+      },
+      {
+        "title": "Parking",
+        "items": [
+          "Private parking is available at a location nearby (reservation is not needed) and costs EUR 37 per day."
+        ]
+      },
+      {
+        "title": "General",
+        "items": [
+          "Newspapers",
+          "Safe",
+          "Non-smoking Rooms",
+          "Facilities for Disabled Guests",
+          "Elevator",
+          "Soundproof Rooms",
+          "Heating",
+          "Hypoallergenic room available",
+          "Air Conditioning",
+          "Designated Smoking Area"
+        ]
+      },
+      {
+        "title": "Languages Spoken",
+        "items": [
+          "English",
+          "French",
+          "German",
+          "Italian",
+          "Russian",
+          "Spanish"
+        ]
+      }
+    ]
+  },
+
+  "breadcrumbs": {
+    "links": [
+      { "title": "USA", "href": "/usa" },
+      { "title": "Tennessee", "href": "/tennessee" },
+      { "title": "Nashville", "href": "/nashville" }
+    ]
+  },
+
+  "numberList": [
+    {
+      "title": "New online test in Australia hopes to encourage people to seek early skin cancer treatment",
+      "url": "http://www.lonelyplanet.com/news#ixzz43kczbTEi"
+    },
+    {
+      "title": "Rugby’s Lions Tour to be huge draw for UK and Irish visitors to New Zealand",
+      "url": "http://www.lonelyplanet.com/news#ixzz43kd8jfjx"
+    },
+    {
+      "title": "Single day tickets for Chicago’s Lollapalooza music festival now on sale",
+      "url": "http://www.lonelyplanet.com/news#ixzz43kkox8n3"
+    },
+    {
+      "title": "New Mexico police hunt flying saucer missing from UFO museum in Roswell",
+      "url": "http://www.lonelyplanet.com/news#ixzz43kkvuGLJ"
+    },
+    {
+      "title": "Videos of the week: celebrating daredevils, divers, and historic speeches",
+      "url": "http://www.lonelyplanet.com/news#ixzz43kl1y2Wp"
+    }
+  ],
+
+  "tour": {
+    "itinerary": [
+      {
+        "day": 1,
+        "title": "Day 1 San Francisco",
+        "description": "There's a lot to see and do in San Francisco, and we recommend spending extra time here if you'd like to explore the city; speak to your sales agent to book extra accommodation. Haight-Ashbury, Alcatraz, the Golden Gate Bridge, Fisherman's Wharf, and the city's famous cable cars await you.\n\nIncluded Activities:\nArrival Day and Welcome Meeting"
+      },
+      {
+        "day": 2,
+        "title": "Day 2 San Francisco/Yosemite National Park (1D)",
+        "description": "Travel through California's Sierra Nevada Mountains on the way to Yosemite National Park. Set up camp for the night and get ready for a full day of exploring the next day.\n\nTransport:\nPrivate Vehicle (7.00 hour(s), 225km)"
+      },
+      {
+        "day": 3,
+        "title": "Day 3 Yosemite National Park (1B, 1L, 1D)",
+        "description": "Admire spectacular views of Yosemite National Park's magnificent peaks and granite domes. Yosemite has many trails to offer. Be inspired by this beautiful and amazing landscape and opt to rent a bike to better explore the Yosemite Valley.\n\nIncluded Activities:\nYosemite National Park Visit"
+      },
+      {
+        "day": 4,
+        "title": "Day 4 Yosemite National Park/Bishop (1B, 1L, 1D)",
+        "description": "Marvel at the spectacular views of Yosemite National Park's magnificent peaks and granite domes while enjoying one of most scenic areas in California. \n\nAdditional Notes:\nNote: we intend on using the Tioga Pass, a scenic route through the Sierra Nevada mountain range that connects Yosemite NP with Bishop. In the spring and autumn seasons, there's a chance that the pass will be closed due to poor weather conditions or even snow. In such a case, we use an alternate route south, and will spend the night in Lake Isabella instead of Bishop. The status of the road is monitored daily, and our travel plan for the area will be confirmed during the trip.\n\nIncluded Activities:\nTioga Pass Drive\nMono Lake Visit\n\nTransport:\nPrivate Vehicle (10.00 hour(s), 330km)"
+      },
+      {
+        "day": 5,
+        "title": "Day 5 Bishop/Las Vegas (1B, 1L)",
+        "description": "Visit one of the country's most rugged landscapes, legendary Death Valley, the hottest and driest spot on earth and home to the lowest point in North America.\n\nAdditional Notes:\nFor the nights in Las Vegas, we stay close to the action in a hotel either at the end of or just a few blocks off the Strip.\n\nIncluded Activities:\nDeath Valley National Park Visit\nVegas Strip Visit \n\nTransport:\nPrivate Vehicle (10.00 hour(s), 590km)"
+      },
+      {
+        "day": 6,
+        "title": "Day 6 Las Vegas",
+        "description": "Full day to explore Las Vegas. Walk the strip and try your luck at the tables or slot machines. Or spend the day shopping, dining or poolside. In the evening, opt to see one of the wildly entertaining shows Vegas is known for."
+      },
+      {
+        "day": 7,
+        "title": "Day 7 Las Vegas/Grand Canyon National Park (1D)",
+        "description": "Considered among nature's most spectacular offerings, the Grand Canyon provides spectacular opportunities for exploration. Return to the campsite and recapture the experiences from this memorable day! \n\nIncluded Activities:\nGrand Canyon Sunset\n\nTransport:\nPrivate Vehicle (6.00 hour(s), 475km)"
+      },
+      {
+        "day": 8,
+        "title": "Day 8 Grand Canyon National Park (1B, 1L, 1D)",
+        "description": "Enjoy a free day to discover the Grand Canyon. Opt to wander throughout the park and take a hike. Hire a bike, check out a museum or see the canyon from the sky by helicopter.\n\nAdditional Notes:\nNote: If you have pre-booked the Grand Canyon Helicopter Ride you will enjoy your 45-50min ride over the canyon today.\n\nIncluded Activities:\nGrand Canyon South Rim Visit"
+      },
+      {
+        "day": 9,
+        "title": "Day 9 Grand Canyon National Park/Monument Valley (1B, 1L)",
+        "description": "Take an optional jeep tour led by a Navajo guide through Monument Valley and be inspired by a night under the stars while camping in this magnificent atmosphere. \n\nTransport:\nPrivate Vehicle (5.00 hour(s), 290km)"
+      },
+      {
+        "day": 10,
+        "title": "Day 10 Monument Valley/Durango (1B, 1L, 1D)",
+        "description": "Hike through history exploring Mesa Verde National Park, which offers a spectacular look into the lives of the Ancestral Puebloans. \n\nIncluded Activities:\nMesa Verde Guided Tour\n\nTransport:\nApproximate Distance to Durango: 315 km\nPrivate Vehicle (7.00 hour(s))"
+      },
+      {
+        "day": 11,
+        "title": "Day 11 Durango/Santa Fe (1B, 1L)",
+        "description": "Continue the journey back in time and explore one of America's oldest and most beautiful cities, Santa Fe. Take a stroll downtown and visit art galleries, or enjoy some world-famous roasted green chilies.\n\nTransport:\nPrivate Vehicle (6.00 hour(s), 350km)"
+      },
+      {
+        "day": 12,
+        "title": "Day 12 Santa Fe/Carlsbad (1B, 1L, 1D)",
+        "description": "Look for aliens at infamous Roswell en route to exploring the Carlsbad Caverns, dodging the 400,000 bats heading out to hunt at sunset.\n\nIncluded Activities:\nExplore Roswell\nCarlsbad Caverns Tour\n\nTransport:\nPrivate Vehicle (8.00 hour(s), 470km)"
+      },
+      {
+        "day": 13,
+        "title": "Day 13 Carlsbad/Austin (1B, 1L)",
+        "description": "Sit back and gaze at the scenery while travelling through the southern United States. Upon arrival in the 'Lonestar' state, settle in at the campsite for a night under the stars.\n\nTransport:\nPrivate Vehicle (9.00 hour(s), 764km)"
+      },
+      {
+        "day": 14,
+        "title": "Day 14 Austin (1B)",
+        "description": "Spend a free day in Austin. Opt to visit the SoCo area for thrift shopping, take a dip in the Barton natural pool, or let loose at a local country bar in the evening."
+      },
+      {
+        "day": 15,
+        "title": "Day 15 Austin/New Orleans (1B)",
+        "description": "The CEO will point out a few things on the drive in, then get out and experience the city at its best.\n\nTransport:\nPrivate Vehicle (9.00 hour(s), 820km)"
+      },
+      {
+        "day": 16,
+        "title": "Day 16 New Orleans (1B)",
+        "description": "New travellers may join you today for the rest of the adventure. You are welcome to join them at a group meeting this evening, followed by an optional dinner."
+      },
+      {
+        "day": 17,
+        "title": "Day 17 New Orleans/Memphis (1B, 1L)",
+        "description": "Explore the birthplace of Rock 'n' Roll, the Home of Blues, and the starting point of soul. Music legends, including Elvis Presley, Johnny Cash and B.B. King, made their marks on Memphis. Optional activities include visiting the National Civil Rights Museum (located where the assassination of Martin Luther King Jr took place in 1968) or visiting the Rock ‘n’ Soul Museum. \n\nTransport:\nPrivate Vehicle (8.00 hour(s), 640km)"
+      },
+      {
+        "day": 18,
+        "title": "Day 18 Memphis/Nashville (1B, 1L, 1D)",
+        "description": "In the morning, opt to walk in the footsteps of the King of Rock ‘n’ Roll at Elvis Presley’s home, Graceland. If Graceland is not for you, enjoy the time to explore more of Memphis on your own.  Travel to Nashville in time to check out the nightlife and visit a real country cowboy bar.\n\nTransport:\nPrivate Vehicle (5.00 hour(s), 380km)"
+      },
+      {
+        "day": 19,
+        "title": "Day 19 Nashville/Appalachia (1B, 1L, 1D)",
+        "description": "Experience the Appalachian Mountains on the drive. The mountains are a perfect place to relax and to enjoy the fresh, clean air and see the true beauty of North America. \n\nTransport:\nPrivate Vehicle (8.00 hour(s), 575km)"
+      },
+      {
+        "day": 20,
+        "title": "Day 20 Appalachia/Washington DC (1B, 1L, 1D)",
+        "description": "Continue on the Skyline Drive through Shenandoah National Park, a truly beautiful, historic national treasure. Standing on top of the peaks of Shenandoah National Park, gaze across the silent mountains. It's hard to believe Washington DC is just a short distance away. \n\nIncluded Activities:\nArlington Cemetery Visit\nMonuments by Moonlight\n\nTransport:\nPrivate Vehicle (7.00 hour(s), 480km)"
+      },
+      {
+        "day": 21,
+        "title": "Day 21 Washington DC (1B)",
+        "description": "There is so much to see and do in Washington DC that you can't see it all in one day. Take your time and spend a full day exploring this fascinating city. "
+      },
+      {
+        "day": 22,
+        "title": "Day 22 Washington DC/New York City (1B, 1L)",
+        "description": "Dive into the hustle and bustle of the Big Apple. Opt to visit Times Square, stroll Central Park or check out Greenwich Village. Experience the famous nightlife of New York.\n\nAdditional Notes:\nFor our time in NYC, we stay close to the action in a hostel near the city centre.\n\nIncluded Activities:\nOrientation Walk\n\nTransport:\nPrivate Vehicle (6.00 hour(s), 375km)"
+      },
+      {
+        "day": 23,
+        "title": "Day 23 New York City",
+        "description": "From the Statue of Liberty to Ground Zero to Chinatown, New York City is full of things to do and see. We recommend spending extra time here; please speak to your sales agent to book extra accommodation. \n\nIncluded Activities:\nDeparture Day"
+      }
+    ]
+  }
+}

--- a/stories/icons.jsx
+++ b/stories/icons.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import styles from "./styles.json";
+import Icon from "../src/components/icon";
+
+function Icons() {
+  const rows = [];
+
+  Object.keys(Icon).forEach((iconName) => {
+    rows.push(
+      <tr>
+        <td>{React.createElement(Icon[iconName])}</td>
+        <td>{iconName}</td>
+      </tr>
+    );
+  });
+
+  return (
+    <div style={styles.main}>
+      <h1>Iconography</h1>
+
+      <table>
+        {rows}
+      </table>
+    </div>
+  );
+}
+
+export default Icons;

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -1,0 +1,637 @@
+import React from "react";
+import { storiesOf, action } from "@kadira/storybook";
+import data from "./data.json";
+import Colors from "./Colors";
+import Amenities from "../src/components/amenities";
+// Availability
+import Bookmark from "../src/components/bookmark";
+import Breadcrumbs from "../src/components/breadcrumbs";
+import Button from "../src/components/button";
+import Calendar from "../src/components/calendar";
+import Callout from "../src/components/callout";
+import Checkbox from "../src/components/form/checkbox";
+// ContactBar
+// ContentBlock
+// ContentHeader
+// ContentSectionList
+// Decoration
+import DotLoader from "../src/components/dotLoader";
+import Dropdown from "../src/components/dropdown";
+import EditLink from "../src/components/editLink";
+import ExpandButton from "../src/components/expandButton";
+import Flyout from "../src/components/flyout";
+import Heading from "../src/components/heading";
+import Icons from "./icons";
+import IconButton from "../src/components/iconButton";
+import ImageCarousel from "../src/components/imageCarousel";
+// ImageGallery
+import ImageHero from "../src/components/imageHero";
+// LastUpdated
+import Lede from "../src/components/lede";
+// ListItem
+// ListItemBookable
+// ListItemImage
+// ListItemWireframe
+// Loading
+// Location
+import MapMarker from "../src/components/mapMarker";
+// MobileToolbar
+// Modal
+import MoreLink from "../src/components/moreLink";
+import Narrative from "../src/components/narrative";
+import NoResults from "../src/components/noResults";
+import NumberList from "../src/components/numberList";
+import NumberMarker from "../src/components/numberMarker";
+// Overlay
+import PageHeader from "../src/components/pageHeader";
+import PaginatorButton from "../src/components/paginatorButton";
+import Placeholder from "../src/components/placeholder";
+import PoiPaginator from "../src/components/poiPaginator";
+// Price
+import Profile from "../src/components/profile";
+import ProviderLogo from "../src/components/providerLogo";
+import Rating from "../src/components/rating";
+import RelatedTour from "../src/components/relatedTour";
+import ReviewedBadge from "../src/components/reviewedBadge";
+import Select from "../src/components/form/select";
+import ShareMenu from "../src/components/shareMenu";
+// SidebarSection
+import StaticMap from "../src/components/staticMap";
+import Strapline from "../src/components/strapline";
+import Tag from "../src/components/tag";
+import TagList from "../src/components/tagList";
+// Takeover
+import Tooltip from "../src/components/tooltip";
+import TourItinerary from "../src/components/tourItinerary";
+import TypeSelector from "../src/components/typeSelector";
+
+storiesOf("Styles", module)
+  .add("Colors", () => (
+    <Colors />
+  ));
+
+storiesOf("Iconography", module)
+  .add("Icons", () => (
+    <Icons />
+  ));
+
+storiesOf("Amenities", module)
+  .add("2-column, single list", () => (
+    <Amenities
+      columns={2}
+      listType="single"
+      items={data.amenities.singleList}
+    />
+  ))
+  .add("3-column, grouped list", () => (
+    <Amenities
+      columns={3}
+      listType="grouped"
+      items={data.amenities.groupedList}
+    />
+  ));
+
+storiesOf("Bookmark", module)
+  .add("Default", () => (
+    <Bookmark />
+  ));
+
+storiesOf("Breadcrumbs", module)
+  .add("Default", () => (
+    <Breadcrumbs
+      links={data.breadcrumbs.links}
+      listType="single"
+      items={data.amenities.singleList}
+    />
+  ));
+
+storiesOf("Button", module)
+  .add("Primary", () => (
+    <Button onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Primary, rounded", () => (
+    <Button rounded onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Primary, tiny", () => (
+    <Button size="tiny" onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Primary, small", () => (
+    <Button size="small" onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Primary, large", () => (
+    <Button size="large" onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Primary, huge", () => (
+    <Button size="huge" onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Primary, disabled", () => (
+    <Button disabled onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Primary, full width", () => (
+    <Button full onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Secondary", () => (
+    <Button color="white" onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Secondary, border", () => (
+    <Button color="white" border onClick={action("clicked")}>Hello Button</Button>
+  ))
+  .add("Secondary, rounded border", () => (
+    <Button color="white" rounded border onClick={action("clicked")}>Hello Button</Button>
+  ));
+
+storiesOf("Calendar", module)
+  .add("Default", () => (
+    <Calendar />
+  ));
+
+storiesOf("Callout", module)
+  .add("Book", () => (
+    <Callout
+      type="book"
+      align="center"
+      heading="Lonely Planet’s Best in Travel 2016"
+      slug="/"
+      price={{
+        currency: "USD",
+        amount: 21.99,
+      }}
+      description={`Be an in-the-know traveler this year with Lonely
+        Planet’s collection of the hottest trends, destinations,
+        journeys.`}
+      image="http://dummyimage.com/132x168/4d494d/686a82.gif"
+    />
+  ))
+  .add("Activity", () => (
+    <Callout
+      type="activity"
+      heading="Cycle Linz to Vienna"
+      slug="/"
+      price={{
+        currency: "USD",
+        amount: 50,
+      }}
+      image="http://dummyimage.com/300x158/4d494d/686a82.gif"
+      category="Food and drink"
+    />
+  ));
+
+storiesOf("Checkbox", module)
+  .add("Default", () => (
+    <Checkbox
+      value="5 star hotel"
+      id="check"
+      checked
+    />
+  ));
+
+storiesOf("Dot loader", module)
+  .add("Default", () => (
+    <DotLoader inline={false} />
+  ));
+
+storiesOf("Dropdown", module)
+  .add("Default", () => (
+    <Dropdown
+      options={["AUD", "EUR", "GBP", "USD"]}
+      defaultValue="USD"
+      onChange={action(event)}
+    />
+  ));
+
+storiesOf("Edit link", module)
+  .add("Default", () => (
+    <EditLink url="/" />
+  ));
+
+storiesOf("Expand button", module)
+  .add("Default", () => (
+    <ExpandButton label="Open" />
+  ));
+
+storiesOf("Flyout", module)
+  .add("Small", () => (
+    <Flyout children="I believe I can fly…" />
+  ))
+  .add("Medium", () => (
+    <Flyout children="I believe I can fly…" size="medium" arrow="right" />
+  ))
+  .add("Fill", () => (
+    <Flyout children="I believe I can fly…" fill />
+  ));
+
+storiesOf("Heading", module)
+  .add("Tiny", () => (
+    <Heading size="tiny">Tiny heading</Heading>
+  ))
+  .add("Small", () => (
+    <Heading size="small">Small heading</Heading>
+  ))
+  .add("Medium (default)", () => (
+    <Heading>Medium heading</Heading>
+  ))
+  .add("Large", () => (
+    <Heading size="large">Large heading</Heading>
+  ))
+  .add("Huge", () => (
+    <Heading size="huge">Huge heading</Heading>
+  ))
+  .add("Thick", () => (
+    <Heading weight="thick">Thick heading</Heading>
+  ))
+  .add("Thin", () => (
+    <Heading weight="thin">Thin heading</Heading>
+  ))
+  .add("Alert importance", () => (
+    <Heading importance="alert">Alert importance heading</Heading>
+  ))
+  .add("High importance", () => (
+    <Heading importance="high">High importance heading</Heading>
+  ))
+  .add("Low importance", () => (
+    <Heading importance="low">Low importance heading</Heading>
+  ))
+  .add("Tight tracking", () => (
+    <Heading tracking="tight">Tight tracking heading</Heading>
+  ))
+  .add("Loose tracking", () => (
+    <Heading tracking="loose">Loose tracking heading</Heading>
+  ))
+  .add("Capitalized", () => (
+    <Heading caps>Capitalized heading</Heading>
+  ));
+
+storiesOf("Icon button", module)
+  .add("Default", () => (
+    <IconButton
+      icon="share"
+      label="Share this"
+    />
+  ));
+
+storiesOf("Image carousel", module)
+  .add("Default", () => (
+    <ImageCarousel
+      images={[
+        "https://s3.amazonaws.com/static-asset/backpack-ui/scotland-1.770x430.jpg",
+        "https://s3.amazonaws.com/static-asset/backpack-ui/scotland-2.770x430.jpg",
+        "https://s3.amazonaws.com/static-asset/backpack-ui/scotland-3.770x430.jpg",
+      ]}
+      imageSize={[770, 430]}
+      index={null}
+    />
+  ));
+
+storiesOf("Image hero", module)
+  .add("Default", () => (
+    <ImageHero
+      image="https://s3.amazonaws.com/static-asset/backpack-ui/ImageHero.770x430.jpg"
+      imageSize={[770, 430]}
+    />
+  ));
+
+storiesOf("Lede", module)
+  .add("Default", () => (
+    <Lede
+      content={`Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit, sed do eiusmod tempor incididunt
+        ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris
+        nisi ut aliquip ex ea commodo consequat. Duis aute
+        irure dolor in reprehenderit in voluptate velit
+        esse cillum dolore eu fugiat nulla pariatur.
+        Excepteur sint occaecat cupidatat non proident,
+        sunt in culpa qui officia deserunt mollit anim id
+        est laborum`}
+    />
+  ));
+
+storiesOf("Map marker", module)
+  .add("Sights", () => (
+    <MapMarker
+      poiType="sights"
+      size={128}
+      hideShadow
+    />
+  ))
+  .add("Sights inverse", () => (
+    <MapMarker
+      poiType="sights"
+      size={128}
+      inverse
+    />
+  ));
+
+storiesOf("More link", module)
+  .add("Default", () => (
+    <MoreLink
+      href="/"
+      children="View all tours"
+    />
+  ));
+
+storiesOf("Narrative", module)
+  .add("Default", () => (
+    <Narrative
+      heading="Walking into the Sacher is like turning back the clocks 100 years."
+      htmlContent={`<p>The reception, with its dark-wood panelling, deep red shades
+        and heavy gold chandelier, is reminiscent of an expensive fin de siècle
+        bordello. The smallest rooms are surprisingly large and suites are truly
+        palatial. Junior suites/doubles cost from €480 to €1350.</p>
+        <p>As well as extras like original oil paintings throughout and a tiny
+        cube of the hotel’s famous Sacher Torte on arrival, there's a hi-tech
+        spa complex, with herbal sauna, ice fountain and fitness room.</p>`}
+      author={{
+        name: "Tim Plaum",
+        title: "Lonely Planet Editor",
+        avatar: "",
+        url: "",
+      }}
+    />
+  ));
+
+storiesOf("No results", module)
+  .add("Default", () => (
+    <NoResults onReset={action(event)} />
+  ));
+
+storiesOf("Number list", module)
+  .add("Default", () => (
+    <NumberList list={data.numberList} />
+  ));
+
+storiesOf("Number marker", module)
+  .add("Default", () => (
+    <NumberMarker number={4} />
+  ));
+
+storiesOf("Placeholder", module)
+  .add("Default", () => (
+    <Placeholder title="The best place in the world" />
+  ));
+
+storiesOf("POI Paginator", module)
+  .add("Default", () => (
+    <PoiPaginator
+      title="Bademiya"
+      type="Fusion restaurant"
+      neighborhood="Hofburg"
+      place="Vienna"
+      topChoice
+    />
+  ));
+
+storiesOf("Profile", module)
+  .add("Large, vertical", () => (
+    <Profile
+      name="Jane Doe"
+      title="Lonely Planet Writer"
+      avatar="//assets.staticlp.com/profiles/users/placeholders/large.png"
+      profileUrl=""
+      size="large"
+      orientation="vertical"
+    />
+  ))
+  .add("Small, horizontal", () => (
+    <Profile
+      name="Jane Doe"
+      title="Lonely Planet Writer"
+      avatar="//assets.staticlp.com/profiles/users/placeholders/large.png"
+      profileUrl=""
+      size="small"
+      orientation="horizontal"
+    />
+  ));
+
+storiesOf("Provider logo", module)
+  .add("booking.com", () => (
+    <ProviderLogo provider="bdc" />
+  ))
+  .add("Hostelworld", () => (
+    <ProviderLogo provider="hostelworld" />
+  ))
+  .add("OpenTable", () => (
+    <ProviderLogo provider="opentable" />
+  ))
+  .add("G Adventures", () => (
+    <ProviderLogo provider="gadventures" />
+  ))
+  .add("Viator", () => (
+    <ProviderLogo provider="viator" />
+  ));
+
+storiesOf("Rating", module)
+  .add("Icon", () => (
+    <Rating
+      amount={3.5}
+      max={5}
+      icon
+    />
+  ))
+  .add("Text", () => (
+    <Rating
+      provider="bdc"
+      amount={8}
+      max={10}
+      description="Great"
+    />
+  ));
+
+storiesOf("Page header", module)
+  .add("Default", () => (
+    <PageHeader
+      heading="Ryman Auditorium"
+      title="Nashville sights"
+      titleHref="/"
+      topChoice
+      type="Historic building"
+      place="Nashville"
+      alignment="center"
+    />
+  ));
+
+storiesOf("Paginator button", module)
+  .add("Up (default)", () => (
+    <PaginatorButton
+      direction="up"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Down", () => (
+    <PaginatorButton
+      direction="down"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Left", () => (
+    <PaginatorButton
+      direction="left"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Right", () => (
+    <PaginatorButton
+      direction="right"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Medium (default)", () => (
+    <PaginatorButton
+      size="medium"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Small", () => (
+    <PaginatorButton
+      size="small"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Loose shadow (default)", () => (
+    <PaginatorButton
+      shadow="loose"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Tight shadow", () => (
+    <PaginatorButton
+      shadow="tight"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Chevron arrow (default)", () => (
+    <PaginatorButton
+      arrow="chevron"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Triangle arrow", () => (
+    <PaginatorButton
+      arrow="triangle"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ))
+  .add("Blue arrow", () => (
+    <PaginatorButton
+      color="blue"
+      onClick={action("PaginatorButton clicked")}
+    />
+  ));
+
+storiesOf("Related tour", module)
+  .add("Default", () => (
+    <RelatedTour
+      title="Vienna City by Bike and Boat"
+      slug="/#"
+      image="http://dummyimage.com/630x284/4d494d/686a82.gif"
+      price={{
+        currency: "USD",
+        amount: 2595,
+      }}
+      tripLength="14 days"
+      destination="Kochi to Kolkata"
+      reviews={8}
+    />
+  ));
+
+storiesOf("Reviewed badge", module)
+  .add("Default", () => (
+    <ReviewedBadge />
+  ));
+
+storiesOf("Select", module)
+  .add("Default", () => (
+    <Select options={["USA", "France", "Spain"]} />
+  ));
+
+storiesOf("Share menu", module)
+  .add("Default", () => (
+    <ShareMenu
+      text="Text"
+      url="http://www.lonelyplanet.com/"
+      mobile={false}
+    />
+  ));
+
+storiesOf("Static map", module)
+  .add("Default", () => (
+    <StaticMap
+      location="-86.8595257,35.93225029999999"
+      size="278x90"
+    />
+  ));
+
+storiesOf("Strapline", module)
+  .add("Default", () => (
+    <Strapline>
+      Strapline text
+    </Strapline>
+  ));
+
+storiesOf("Tag", module)
+  .add("Default", () => (
+    <Tag
+      label="The Americas"
+      slug="/americas"
+    />
+  ));
+
+storiesOf("Tag list", module)
+  .add("Default", () => (
+    <TagList
+      tags={[
+        { label: "The Americas", slug: "/americas" },
+        { label: "World", slug: "/world" },
+        { label: "Asia & the Pacific", slug: "/asia-pacific" },
+        { label: "Europe", slug: "/europe" },
+        { label: "Middle East & Africa", slug: "/middle-east-africa" },
+        { label: "Editor's pick", slug: "/editors-pick" },
+      ]}
+    />
+  ));
+
+
+storiesOf("Tooltip", module)
+  .add("Default", () => (
+    <Tooltip
+      label="Mouseover me"
+      flyout={{
+        arrow: "down",
+        size: "medium",
+        removePadding: false,
+        shadow: "large",
+        style: {
+          bottom: "40px",
+          left: 0,
+          position: "absolute",
+        },
+      }}
+    >
+      Tooltip content
+    </Tooltip>
+  ));
+
+storiesOf("Tour itinerary", module)
+  .add("Default", () => (
+    <TourItinerary
+      itinerary={data.tour.itinerary}
+      link="/"
+    />
+  ));
+
+storiesOf("Type selector", module)
+  .add("Default", () => (
+    <TypeSelector
+      title="Activities"
+      menuItems={[
+        { item: "Hotels", slug: "#" },
+        { item: "Restaurants", slug: "#" },
+        { item: "Sights", slug: "#" },
+        { item: "Entertainment", slug: "#" },
+        { item: "Acitivities", slug: "#" },
+        { item: "Tours", slug: "#" },
+        { item: "Articles", slug: "#" },
+        { item: "News", slug: "#" },
+      ]}
+    />
+  ));

--- a/stories/styles.json
+++ b/stories/styles.json
@@ -1,0 +1,8 @@
+{
+  "main": {
+    "fontFamily": "'Helvetica Neue', 'Helvetica', 'Segoe UI', 'Arial', sans-serif",
+    "lineHeight": 1.4,
+    "maxWidth": 600,
+    "margin": 15
+  }
+}


### PR DESCRIPTION
This is still a work-in-progress, but I thought it would be good to get it merged so others can use it.

There are still a few outstanding issues and things to work through:
- Some components don't render because they use media queries or keyframes applied via Radium. Radium requires a `StyleRoot` component to wrap components that use these features. In our current situation, the `StyleRoot` component is applied at the app level and not on a per-component basis.
- Some components have not yet been added to the Storybook; you will see these component names commented out in stories/index.jsx
- Lack of a global stylesheet; this may actually be a feature because it allows us to see the shortcomings of each component and add the appropriate styles to make the component fully reusable across multiple apps. However, there are some global styles that can't be applied via inline styles to each component; styles such as box-sizing are important to each component's structure, but need a stylesheet, unless we define box-sizing on each component, which is possible.