### PR TITLE
Update component styles

### DIFF
--- a/src/components/amenities/index.jsx
+++ b/src/components/amenities/index.jsx
@@ -2,12 +2,14 @@ import React from "react";
 import radium from "radium";
 import { color } from "../../../settings.json";
 import { span } from "../../utils/grid";
+import font from "../../utils/font";
 
 const baseFontSize = 13;
 
 const styles = {
   container: {
     base: {
+      fontFamily: font("benton"),
       fontSize: `${baseFontSize}px`,
       lineHeight: (24 / baseFontSize),
     },
@@ -15,11 +17,16 @@ const styles = {
 
   list: {
     base: {
-      marginTop: `${-5 / baseFontSize}em`, // bring top of text 30px from header
+      listStyle: "none",
+      marginTop: 0,
+      marginRight: 0,
+      marginBottom: 0,
+      marginLeft: 0,
+      padding: 0,
     },
 
     single: {
-      listStyle: "none",
+      marginTop: `${-5 / baseFontSize}em`, // bring top of text 30px from header
     },
 
     grouped: {
@@ -31,8 +38,6 @@ const styles = {
     base: {
       color: color.darkGray,
     },
-
-    single: {},
 
     grouped: {
       base: {
@@ -47,14 +52,12 @@ const styles = {
   },
 
   heading: {
-    base: {},
-
-    single: {},
-
-    grouped: {
+    base: {
+      color: color.titleGray,
       fontSize: `${14 / baseFontSize}em`,
-      lineHeight: (24 / 14),
       fontWeight: 600,
+      lineHeight: (24 / 14),
+      margin: 0,
     },
   },
 };
@@ -85,11 +88,11 @@ const getGroupedItems = (items) => {
         style={groupedItemStyle}
         key={index}
       >
-        <h5 style={styles.heading.grouped}>
+        <h5 style={styles.heading.base}>
           {group.title}
         </h5>
 
-        <ul style={styles.list.single}>
+        <ul style={styles.list.base}>
           {getListItems(group.items, group.capitalize, "grouped")}
         </ul>
       </div>
@@ -108,7 +111,7 @@ function Amenities({ columns, items = [], listType }) {
   const style = {
     list: {
       single: [styles.list.base, styles.list.single],
-      grouped: [styles.list.base, styles.list.grouped],
+      grouped: [styles.list.base, styles.list.single, styles.list.grouped],
     },
   };
 

--- a/src/components/breadcrumbs/index.jsx
+++ b/src/components/breadcrumbs/index.jsx
@@ -5,6 +5,7 @@ import { color } from "../../../settings.json";
 import Icon from "../icon";
 import { blueLink } from "../../utils/mixins";
 import schema from "../../utils/schema";
+import font from "../../utils/font";
 
 const _ = { capitalize };
 
@@ -12,6 +13,7 @@ const styles = {
   container: {
     base: {
       color: color.lightText,
+      fontFamily: font("benton"),
       fontSize: "14px",
       fontWeight: 400,
       lineHeight: 1,
@@ -80,12 +82,9 @@ function Breadcrumbs({ links }) {
       </a>
 
       {index < links.length - 1 &&
-        <Icon
-          name="chevron-right"
-          dimensions={{
-            width: `${6 / 14}em`,
-            height: `${6 / 14}em`,
-          }}
+        <Icon.ChevronRight
+          width={`${6 / 14}em`}
+          height={`${6 / 14}em`}
         />
       }
 

--- a/src/components/contentHeader/index.jsx
+++ b/src/components/contentHeader/index.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import radium from "radium";
+import assign from "object-assign";
 import settings from "../../../settings.json";
 import Heading from "../heading";
 import MoreLink from "../moreLink";
@@ -52,12 +53,14 @@ function ContentHeader({ title, heading, border, moreLink }) {
     "ContentHeader clearfix" :
     "ContentHeader";
 
+  const headingStyle = assign({}, hasLink ? styles.heading.base : {}, heading.override);
+
   return (
     <header
       className={headerClassName}
       style={style.container}
     >
-      <Heading {...heading} override={[hasLink && styles.heading.base, heading.override]}>
+      <Heading {...heading} override={headingStyle}>
         {title}
       </Heading>
 

--- a/src/components/contentHeader/index.jsx
+++ b/src/components/contentHeader/index.jsx
@@ -53,7 +53,7 @@ function ContentHeader({ title, heading, border, moreLink }) {
     "ContentHeader clearfix" :
     "ContentHeader";
 
-  const headingStyle = assign({}, hasLink ? styles.heading.base : {}, heading.override);
+  const headingStyle = assign({}, hasLink && styles.heading.base, heading.override);
 
   return (
     <header

--- a/src/components/expandButton/index.jsx
+++ b/src/components/expandButton/index.jsx
@@ -3,6 +3,9 @@ import radium from "radium";
 import settings from "../../../settings.json";
 import Icon from "../icon";
 import { rgb } from "../../utils/color";
+import font from "../../utils/font";
+
+const baseFontSize = 14;
 
 const hoverStyles = {
   backgroundColor: `rgba(${rgb(settings.color.black)}, .9)`,
@@ -12,12 +15,17 @@ const styles = {
   container: {
     base: {
       backgroundColor: `rgba(${rgb(settings.color.black)}, .6)`,
-      borderRadius: `${4 / 14}em`,
+      border: 0,
+      borderRadius: `${4 / baseFontSize}em`,
       color: settings.color.white,
+      cursor: "pointer",
       display: "block",
-      fontSize: "14px",
-      padding: `${4 / 14}em ${5 / 14}em ${3 / 14}em ${10 / 14}em`,
+      fontFamily: font("benton"),
+      fontSize: `${baseFontSize}px`,
+      lineHeight: 1,
+      padding: `${5 / baseFontSize}em ${4 / baseFontSize}em ${4 / baseFontSize}em ${7 / baseFontSize}em`,
       transition: `background-color ${settings.timing.default}`,
+      verticalAlign: "baseline",
       width: "auto",
 
       ":hover": hoverStyles,
@@ -28,8 +36,9 @@ const styles = {
 
   label: {
     base: {
-      fontSize: `${10 / 14}em`,
-      marginRight: `${10 / 14}em`,
+      fontSize: `${10 / baseFontSize}em`,
+      marginRight: `${10 / baseFontSize}em`,
+      verticalAlign: "middle",
     },
   },
 };

--- a/src/components/form/checkbox.jsx
+++ b/src/components/form/checkbox.jsx
@@ -194,7 +194,12 @@ Checkbox.propTypes = {
   /**
    * Set the checkbox size
    */
-  size: React.PropTypes.string,
+  size: React.PropTypes.oneOf([
+    "",
+    "full",
+    "half",
+    "third",
+  ]),
 
   /**
    * CSS styles to append to component's styles

--- a/src/components/heading/index.jsx
+++ b/src/components/heading/index.jsx
@@ -2,41 +2,47 @@ import React from "react";
 import radium from "radium";
 import settings from "../../../settings.json";
 import { rgb } from "../../utils/color";
+import font from "../../utils/font";
 
 const styles = {
   base: {
+    fontFamily: font("benton"),
     lineHeight: 1,
+    marginTop: 0,
+    marginRight: 0,
+    marginBottom: 0,
+    marginLeft: 0,
   },
 
   size: {
     tiny: {
-      fontSize: "1.1rem",
+      fontSize: "11px",
     },
     small: {
-      fontSize: "1.1rem",
+      fontSize: "11px",
 
       [`@media (min-width: ${settings.media.min["600"]})`]: {
-        fontSize: "1.3rem",
+        fontSize: "13px",
       },
     },
     medium: {
-      fontSize: "2.6rem",
+      fontSize: "26px",
       lineHeight: (40 / 26),
     },
     large: {
-      fontSize: "4rem",
+      fontSize: "40px",
 
       [`@media (min-width: ${settings.media.min["600"]})`]: {
-        fontSize: "4.5rem",
+        fontSize: "45px",
       },
     },
     huge: {
-      fontSize: "3rem",
-      letterSpacing: "-.1rem",
+      fontSize: "30px",
+      letterSpacing: "-1px",
       lineHeight: (36 / 30),
 
       [`@media (min-width: ${settings.media.min["600"]})`]: {
-        fontSize: "6.4rem",
+        fontSize: "64px",
         lineHeight: (70 / 64),
       },
     },
@@ -205,7 +211,6 @@ Heading.propTypes = {
 
   /**
    * Whether or not to hide the text overflow with an ellipsis
-   * @type {[type]}
    */
   truncate: React.PropTypes.bool,
 
@@ -218,8 +223,7 @@ Heading.propTypes = {
    * Override styles
    */
   override: React.PropTypes.oneOfType([
-    React.PropTypes.objectOf(React.PropTypes.string, React.PropTypes.number),
-    React.PropTypes.arrayOf(React.PropTypes.object),
+    React.PropTypes.object,
   ]),
 };
 

--- a/src/components/icon/index.jsx
+++ b/src/components/icon/index.jsx
@@ -45,6 +45,7 @@ function Icon(props) {
     display: "inline-block",
     fill: fill || "currentColor",
     height: dimensions.height,
+    lineHeight: 1,
     verticalAlign: "middle",
     width: dimensions.width,
   };
@@ -66,13 +67,10 @@ Icon.propTypes = {
   viewBox: React.PropTypes.string.isRequired,
   className: React.PropTypes.string,
   fill: React.PropTypes.string,
-  width: React.PropTypes.string,
-  height: React.PropTypes.string,
+  width: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
+  height: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
   label: React.PropTypes.string,
-  style: React.PropTypes.objectOf(
-    React.PropTypes.string,
-    React.PropTypes.number,
-  ),
+  style: React.PropTypes.oneOfType([React.PropTypes.object]),
 };
 
 Icon.defaultProps = {
@@ -647,51 +645,51 @@ exports.SurvivalWheelchair = props => (
 // Map
 
 exports.MapDefault = props => (
-  <Icon {...props} fill={color.poiDefault}>
+  <Icon fill={color.poiDefault} {...props}>
     <path d="M16 0c-7.1 0-12.8 5.7-12.8 12.8 0 9.6 12.8 19.2 12.8 19.2s12.8-9.6 12.8-19.2c0-7.1-5.7-12.8-12.8-12.8zM16 19.2c-3.5 0-6.4-2.9-6.4-6.4s2.9-6.4 6.4-6.4 6.4 2.9 6.4 6.4-2.9 6.4-6.4 6.4z" />
   </Icon>
 );
 
 exports.MapDrink = props => (
-  <Icon {...props} fill={color.poiDrink}>
+  <Icon fill={color.poiDrink} {...props}>
     <path d="M0 0l4.6 32h22.9l4.5-32h-32zM9.1 13.9l7.3-6.8 6.8 6.8h-14.1z" />
   </Icon>
 );
 
 exports.MapEat = props => (
-  <Icon {...props} fill={color.poiEat}>
+  <Icon fill={color.poiEat} {...props}>
     <path d="M13.2 9.3h-1.1v-9.3h-2.3v9.3h-1.2v-9.3h-2.2v13.8c0 2.1 1.5 3.9 3.4 4.4v13.8h2.3v-13.7c2-0.5 3.4-2.3 3.4-4.4v-13.9h-2.3v9.3z" />
     <path d="M23 0h-2.7v32h2.3v-13.7h0.4c1.5 0 2.7-1.2 2.7-2.7v-12.9c-0.1-1.5-1.3-2.7-2.7-2.7z" />
   </Icon>
 );
 
 exports.MapPlay = props => (
-  <Icon {...props} fill={color.poiPlay}>
+  <Icon fill={color.poiPlay} {...props}>
     <path d="M31.8 11.4l-4.2-4.2c-0.1 0.2-0.2 0.3-0.3 0.5-0.8 0.8-2.1 0.8-2.9 0s-0.8-2.1 0-2.9c0.1-0.1 0.3-0.2 0.5-0.3l-4.2-4.2c-0.2-0.2-0.6-0.2-0.8 0l-19.7 19.5c-0.2 0.2-0.2 0.6 0 0.8l4.2 4.2c0.1-0.2 0.2-0.3 0.3-0.5 0.8-0.8 2.1-0.8 2.9 0s0.8 2.1 0 2.9c-0.1 0.1-0.3 0.2-0.5 0.3l4.2 4.2c0.2 0.2 0.6 0.2 0.8 0l19.6-19.6c0.4-0.1 0.4-0.5 0.1-0.7zM11.4 12.9l1.5-1.5 1.5 1.5-1.5 1.5-1.5-1.5zM14.5 16l1.5-1.5 1.5 1.5-1.5 1.6-1.5-1.6zM19.1 20.7l-1.5-1.5 1.5-1.5 1.5 1.5-1.5 1.5z" />
   </Icon>
 );
 
 exports.MapSee = props => (
-  <Icon {...props} fill={color.poiSee}>
+  <Icon fill={color.poiSee} {...props}>
     <path d="M16 10.7c-2.9 0-5.3 2.4-5.3 5.3s2.4 5.3 5.3 5.3 5.3-2.4 5.3-5.3c0-2.9-2.4-5.3-5.3-5.3zM16 18.7c-1.5 0-2.7-1.2-2.7-2.7s1.2-2.7 2.7-2.7 2.7 1.2 2.7 2.7c0 1.5-1.2 2.7-2.7 2.7z" />
     <path d="M16 5.3c-8.1 0-16 10.7-16 10.7s7.9 10.7 16 10.7 16-10.7 16-10.7-7.9-10.7-16-10.7zM16.2 24c-4.5 0-8.2-3.6-8.2-8s3.7-8 8.2-8 8.2 3.6 8.2 8-3.6 8-8.2 8z" />
   </Icon>
 );
 
 exports.MapShop = props => (
-  <Icon {...props} fill={color.poiShop}>
+  <Icon fill={color.poiShop} {...props}>
     <path d="M25.6 8h-3.2v-1.9c0-3.4-2.9-6.1-6.4-6.1s-6.4 2.7-6.4 6.1v1.9h-3.2c-0.9 0-1.6 0.7-1.6 1.6v20.8c0 0.9 0.7 1.6 1.6 1.6h19.2c0.9 0 1.6-0.7 1.6-1.6v-20.8c0-0.9-0.7-1.6-1.6-1.6zM19.2 8h-6.4v-1.3c0-1.7 1.4-3.1 3.2-3.1s3.2 1.4 3.2 3.1v1.3z" />
   </Icon>
 );
 
 exports.MapSleep = props => (
-  <Icon {...props} fill={color.poiSleep}>
+  <Icon fill={color.poiSleep} {...props}>
     <path d="M23.8 23.1c-8.2 0-14.9-6.7-14.9-14.9 0-3 0.9-5.8 2.4-8.2-6.5 2.1-11.3 8.3-11.3 15.6 0 9.1 7.3 16.4 16.4 16.4 7.3 0 13.5-4.8 15.6-11.4-2.3 1.6-5.1 2.5-8.2 2.5z" />
   </Icon>
 );
 
 exports.MapTransport = props => (
-  <Icon {...props} fill={color.poiTransport}>
+  <Icon fill={color.poiTransport} {...props}>
     <path d="M26.1 0h-20.2c-1.9 0-3.4 1.5-3.4 3.4v20.2c0 1.9 1.5 3.4 3.4 3.4v0 3.4c0 0.9 0.8 1.7 1.7 1.7s1.7-0.8 1.7-1.7v-3.4h13.5v3.4c0 0.9 0.8 1.7 1.7 1.7s1.7-0.8 1.7-1.7v-3.4c1.9 0 3.4-1.5 3.4-3.4v-20.2c-0.1-1.9-1.6-3.4-3.5-3.4zM10.5 23.1c-0.3 0.3-0.8 0.5-1.2 0.5-0.5 0-0.9-0.2-1.2-0.5s-0.5-0.8-0.5-1.2 0.1-0.9 0.4-1.2 0.8-0.5 1.2-0.5c0.5 0 0.9 0.2 1.2 0.5s0.5 0.8 0.5 1.2-0.1 0.9-0.4 1.2zM24 23.1c-0.3 0.3-0.8 0.5-1.2 0.5-0.5 0-0.9-0.2-1.2-0.5s-0.5-0.8-0.5-1.2 0.2-0.9 0.5-1.2 0.8-0.5 1.2-0.5c0.5 0 0.9 0.2 1.2 0.5s0.5 0.8 0.5 1.2-0.2 0.9-0.5 1.2zM26.1 18.5h-20.2v-15.1h20.2v15.1z" />
   </Icon>
 );

--- a/src/components/iconButton/index.jsx
+++ b/src/components/iconButton/index.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import radium from "radium";
 import assign from "object-assign";
+import upperFirst from "lodash/upperFirst";
 import settings from "../../../settings.json";
 import Icon from "../icon";
 import { darken } from "../../utils/color";
 import { outline } from "../../utils/mixins";
+
+const _ = { upperFirst };
 
 const hoverStyles = {
   backgroundColor: darken(settings.color.white, 12),
@@ -51,7 +54,7 @@ const styles = {
   },
 };
 
-function IconButton({ icon, label, className, href, onClick, size, owns }) {
+function IconButton({ iconName, label, className, href, onClick, size, owns }) {
   const Element = href ? "a" : "button";
   const role = Element === "a" ? "button" : "";
 
@@ -60,6 +63,10 @@ function IconButton({ icon, label, className, href, onClick, size, owns }) {
   if (size) {
     style.push(styles.size[size]);
   }
+
+  const ButtonIcon = React.createElement(Icon[_.upperFirst(iconName)], {
+    label,
+  });
 
   return (
     <Element
@@ -72,9 +79,7 @@ function IconButton({ icon, label, className, href, onClick, size, owns }) {
       aria-label={label}
       aria-owns={owns}
     >
-      <Icon
-        name={icon}
-      />
+      {ButtonIcon}
     </Element>
   );
 }
@@ -83,7 +88,7 @@ IconButton.propTypes = {
   /**
    * Name of the icon to display inside of the button
    */
-  icon: React.PropTypes.string.isRequired,
+  iconName: React.PropTypes.string.isRequired,
 
   /**
    * A descriptive label of the button's purpose
@@ -122,7 +127,7 @@ IconButton.propTypes = {
 };
 
 IconButton.defaultProps = {
-  icon: "",
+  iconName: "",
 
   label: "",
 

--- a/src/components/mapMarker/index.jsx
+++ b/src/components/mapMarker/index.jsx
@@ -7,51 +7,51 @@ import Icon from "../icon";
 function mapMarker({ poiType, size, hideShadow, inverse }) {
   const types = {
     sleeping: {
-      icon: "sleep",
+      icon: "Sleep",
       color: color.poiSleep,
     },
     drinking_nightlife: {
-      icon: "drink",
+      icon: "Drink",
       color: color.poiDrink,
     },
     transport: {
-      icon: "transport",
+      icon: "Transport",
       color: color.poiTransport,
     },
     activities: {
-      icon: "see",
+      icon: "See",
       color: color.poiSee,
     },
     tours: {
-      icon: "see",
+      icon: "See",
       color: color.poiSee,
     },
     entertainment: {
-      icon: "play",
+      icon: "Play",
       color: color.poiPlay,
     },
     shopping: {
-      icon: "shop",
+      icon: "Shop",
       color: color.poiShop,
     },
     eating: {
-      icon: "eat",
+      icon: "Eat",
       color: color.poiEat,
     },
     restaurants: {
-      icon: "eat",
+      icon: "Eat",
       color: color.poiEat,
     },
     sights: {
-      icon: "see",
+      icon: "See",
       color: color.poiSee,
     },
     info: {
-      icon: "default",
+      icon: "Default",
       color: color.poiDefault,
     },
     festivals_events: {
-      icon: "play",
+      icon: "Play",
       color: color.poiPlay,
     },
   };
@@ -128,6 +128,11 @@ function mapMarker({ poiType, size, hideShadow, inverse }) {
     },
   };
 
+  const MarkerIcon = React.createElement(Icon[`Map${types[poiType].icon}`], {
+    style: styles.icon.base,
+    fill: inverse ? types[poiType].color : color.white,
+  });
+
   return (
     <div
       className="MapMarker"
@@ -137,14 +142,7 @@ function mapMarker({ poiType, size, hideShadow, inverse }) {
         inverse && styles.container.inverse,
       ]}
     >
-      <Icon
-        label={poiType}
-        style={styles.icon.base}
-        name={poiType === "center" ?
-          "map-default" :
-          `map-${types[poiType].icon}`
-        }
-      />
+      {poiType === "center" ? <Icon.MapDefault /> : MarkerIcon}
     </div>
   );
 }

--- a/src/components/moreLink/index.jsx
+++ b/src/components/moreLink/index.jsx
@@ -49,7 +49,7 @@ const styles = {
  */
 function MoreLink({ href, size, children, onClick, caps, style }) {
   const Element = href ? "a" : "button";
-  const iconStyle = assign({}, styles.icon.base, size ? styles.icon.size[size] : {});
+  const iconStyle = assign({}, styles.icon.base, size && styles.icon.size[size]);
 
   return (
     <Element

--- a/src/components/moreLink/index.jsx
+++ b/src/components/moreLink/index.jsx
@@ -27,7 +27,6 @@ const styles = {
 
   icon: {
     base: {
-      lineHeight: 1,
       marginLeft: ".5em",
       position: "relative",
       top: `${-2 / 13}em`,
@@ -50,6 +49,7 @@ const styles = {
  */
 function MoreLink({ href, size, children, onClick, caps, style }) {
   const Element = href ? "a" : "button";
+  const iconStyle = assign({}, styles.icon.base, size ? styles.icon.size[size] : {});
 
   return (
     <Element
@@ -67,10 +67,7 @@ function MoreLink({ href, size, children, onClick, caps, style }) {
       <Icon.ChevronRight
         height="6px"
         width="6px"
-        style={[
-          styles.icon.base,
-          size && styles.icon.size[size],
-        ]}
+        style={iconStyle}
       />
     </Element>
   );

--- a/src/components/rating/index.jsx
+++ b/src/components/rating/index.jsx
@@ -3,20 +3,31 @@ import radium from "radium";
 import Icon from "../icon";
 import ProviderLogo from "../providerLogo";
 import schema from "../../utils/schema";
+import font from "../../utils/font";
 
 function Rating({ amount, max, description, provider, icon }) {
+  const styles = {
+    container: {
+      base: {
+        fontFamily: font("benton"),
+        fontSize: "11px",
+        lineHeight: 1.5,
+      },
+    },
+  };
+
   const ratingMap = {
-    0: "0_0",
-    0.5: "0_5",
-    1: "1_0",
-    1.5: "1_5",
-    2: "2_0",
-    2.5: "2_5",
-    3: "3_0",
-    3.5: "3_5",
-    4: "4_0",
-    4.5: "4_5",
-    5: "5_0",
+    0: "RatingZero",
+    0.5: "RatingHalf",
+    1: "RatingOne",
+    1.5: "RatingOneHalf",
+    2: "RatingTwo",
+    2.5: "RatingTwoHalf",
+    3: "RatingThree",
+    3.5: "RatingThreeHalf",
+    4: "RatingFour",
+    4.5: "RatingFourHalf",
+    5: "RatingFive",
   };
 
   const label = amount ? `${amount} rating` : "";
@@ -36,6 +47,7 @@ function Rating({ amount, max, description, provider, icon }) {
     <div
       className="Rating"
       title={label}
+      style={styles.container.base}
       {...schemaProps}
     >
       {amount && icon && ratingMap[amount] &&

--- a/src/components/shareMenu/index.jsx
+++ b/src/components/shareMenu/index.jsx
@@ -169,7 +169,7 @@ class ShareMenu extends React.Component {
       >
         <IconButton
           className="ShareMenu-button"
-          icon="share"
+          iconName="share"
           label="Share this article on Twitter, Facebook, or email"
           owns="share-menu-options"
           onClick={this.toggleOptions}

--- a/src/components/shareMenu/item.jsx
+++ b/src/components/shareMenu/item.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import radium from "radium";
+import upperFirst from "lodash/upperFirst";
 import styles from "./styles";
 import Icon from "../icon";
 
+const _ = { upperFirst };
+
 function ShareMenuItem({ network, href, label, onClick }) {
-  const NetworkIcon = React.createElement(Icon[network], {
+  const NetworkIcon = React.createElement(Icon[_.upperFirst(network)], {
     height: "16px",
     width: "16px",
   });

--- a/src/components/shareMenu/styles.js
+++ b/src/components/shareMenu/styles.js
@@ -1,8 +1,11 @@
 import settings from "../../../settings.json";
+import font from "../../utils/font";
 
 const styles = {
   container: {
     base: {
+      display: "inline-block",
+      fontFamily: font("benton"),
       position: "relative",
     },
 
@@ -21,24 +24,24 @@ const styles = {
       transition: `opacity ${settings.timing.default},
         transform ${settings.timing.default},
         visibility ${settings.timing.default}`,
-      width: "20rem",
+      width: "200px",
     },
 
     position: {
       above: {
-        bottom: "3.8rem",
+        bottom: "38px",
         left: "50%",
       },
       below: {
         left: "50%",
-        top: "3.8rem",
+        top: "38px",
       },
       left: {
-        right: "3.8rem",
+        right: "38px",
         top: "50%",
       },
       right: {
-        left: "3.8rem",
+        left: "38px",
         top: "50%",
       },
     },
@@ -52,16 +55,16 @@ const styles = {
 
         position: {
           above: {
-            transform: "translate(-50%, -1rem)",
+            transform: "translate(-50%, -10px)",
           },
           below: {
-            transform: "translate(-50%, 1rem)",
+            transform: "translate(-50%, 10px)",
           },
           left: {
-            transform: "translate(-1rem, -50%)",
+            transform: "translate(-10px, -50%)",
           },
           right: {
-            transform: "translate(1rem, -50%)",
+            transform: "translate(10px, -50%)",
           },
         },
       },
@@ -95,16 +98,17 @@ const styles = {
       backgroundColor: "transparent",
       color: settings.color.text,
       display: "block",
-      fontSize: "1.3rem",
-      paddingBottom: ".4rem",
-      paddingTop: ".6rem",
+      fontSize: "13px",
+      paddingBottom: "4px",
+      paddingTop: "6px",
       textAlign: "left",
+      textDecoration: "none",
       width: "100%",
     },
 
     label: {
-      paddingLeft: ".6rem",
-      verticalAlign: "-.2rem",
+      paddingLeft: "6px",
+      verticalAlign: "-2px",
     },
   },
 };

--- a/src/components/tag/index.jsx
+++ b/src/components/tag/index.jsx
@@ -2,6 +2,9 @@ import React from "react";
 import radium from "radium";
 import { color, timing } from "../../../settings.json";
 import { rgb } from "../../utils/color";
+import font from "../../utils/font";
+
+const baseFontSize = 12;
 
 const tagColor = "#e1eaf0";
 
@@ -17,13 +20,15 @@ const hoverStyles = {
 
 const styles = {
   base: {
-    border: `${1 / 12}em solid ${tagColor}`,
-    borderRadius: `${17 / 12}em`,
+    border: `${1 / baseFontSize}em solid ${tagColor}`,
+    borderRadius: `${16 / baseFontSize}em`,
     color: color.darkGray,
     display: "inline-block",
-    fontSize: "12px",
+    fontFamily: font("benton"),
+    fontSize: `${baseFontSize}px`,
     lineHeight: 1,
-    padding: `${12 / 12}em ${25 / 12}em ${8 / 12}em`,
+    padding: `${10 / baseFontSize}em ${25 / baseFontSize}em ${8 / baseFontSize}em`,
+    textDecoration: "none",
     textOverflow: "ellipsis",
     transition: `background-color ${timing.default}`,
     whiteSpace: "nowrap",
@@ -47,17 +52,15 @@ const styles = {
  * @usage
  * <Tag label="Europe" slug="/europe" />
  */
-function Tag({ label, slug, selected }) {
-  const style = [styles.base];
-
-  if (selected) {
-    style.push(styles.selected);
-  }
-
+function Tag({ label, slug, selected, style }) {
   return (
     <a
       className="Tag"
-      style={style}
+      style={[
+        styles.base,
+        selected && styles.selected,
+        style,
+      ]}
       href={slug}
     >
       {label}
@@ -80,6 +83,14 @@ Tag.propTypes = {
    * Should the tag appear to have been selected
    */
   selected: React.PropTypes.bool,
+
+  /**
+   * Style object
+   */
+  style: React.PropTypes.objectOf(
+    React.PropTypes.string,
+    React.PropTypes.number,
+  ),
 };
 
 Tag.defaultProps = {
@@ -88,6 +99,8 @@ Tag.defaultProps = {
   slug: "",
 
   selected: false,
+
+  style: null,
 };
 
 Tag.styles = styles;

--- a/src/components/tagList/index.jsx
+++ b/src/components/tagList/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import radium, { Style } from "radium";
+import radium from "radium";
 import Tag from "../tag";
 
 /**
@@ -12,7 +12,7 @@ import Tag from "../tag";
  * ]} />
  */
 function TagList({ tags, rows }) {
-  const rowHeight = 44;
+  const rowHeight = 40;
 
   const styles = {
     container: {
@@ -21,12 +21,19 @@ function TagList({ tags, rows }) {
         overflow: "hidden",
       },
     },
+    tag: {
+      base: {
+        marginBottom: "8px",
+        marginRight: "8px",
+      },
+    },
   };
 
   const Tags = tags.map((tag, i) => (
     <Tag
       label={tag.label}
       slug={tag.slug}
+      style={styles.tag.base}
       selected={tag.selected}
       key={i}
     />
@@ -37,19 +44,10 @@ function TagList({ tags, rows }) {
       className="TagList"
       style={styles.container.base}
     >
-      <Style
-        scopeSelector=".TagList"
-        rules={{
-          ".Tag": {
-            marginBottom: "10px",
-            marginRight: "6px",
-          },
-        }}
-      />
-
       <Tag
         label="All"
         slug="/"
+        style={styles.tag.base}
         selected
       />
       {Tags}


### PR DESCRIPTION
Without a global stylesheet, some components fail to render properly.

Some of the updates include:
- Replacing rem with px because each app may define its own global font
size, which will render the components inconsistently
- Adding reset styles to certain elements, such as removing link
underlines and removing padding, margin on unordered lists
- Setting a font-family on components because there is no global
stylesheet to inherit from
- Update prop types validation