### PR TITLE
Remove custom publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "test:ci": "NODE_ENV=test mocha --reporter spec --compilers js:babel-register --watch --recursive spec/",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "gh-pages": "npm run build-storybook -- -o _gh-pages && gh-pages -d _gh-pages && rm -rf _gh-pages",
-    "publish": "npm run gh-pages"
+    "gh-pages": "npm run build-storybook -- -o _gh-pages && gh-pages -d _gh-pages && rm -rf _gh-pages"
   },
   "author": "Lonely Planet",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backpack-ui",
-  "version": "1.0.0-alpha-9",
+  "version": "1.0.0-alpha-9.1",
   "description": "Lonely Planet's Components",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Seemed to be breaking the publish to the NPM directory and I don't think we need to alias `npm run gh-pages`.