### PR TITLE
Update RelatedArticles component

### DIFF
--- a/src/components/recommendedArticles/index.jsx
+++ b/src/components/recommendedArticles/index.jsx
@@ -6,7 +6,7 @@ import Heading from "../heading";
 import CalloutLink from "../calloutLink";
 import ArticlePreview from "../articlePreview";
 
-function RecommendedArticles({ children }) {
+function RecommendedArticles({ title, calloutLink, calloutTitle, children }) {
   const styles = {
     container: {
     },
@@ -51,30 +51,37 @@ function RecommendedArticles({ children }) {
         }}
       />
 
+      {title &&
       <header>
         <Heading
           level={2}
           weight="thin"
           override={styles.heading}
         >
-          Recommended
+          {title}
         </Heading>
       </header>
+      }
 
       <div style={styles.childrenContainer}>
         {children}
       </div>
 
+      {calloutTitle && calloutLink &&
       <footer style={styles.footer}>
-        <CalloutLink href="/">
-          More recommendations
+        <CalloutLink href={calloutLink}>
+          {calloutTitle}
         </CalloutLink>
       </footer>
+      }
     </section>
   );
 }
 
 RecommendedArticles.propTypes = {
+  title: React.PropTypes.string,
+  calloutLink: React.PropTypes.string,
+  calloutTitle: React.PropTypes.string,
   children: (props, propName, componentName) => {
     const prop = props[propName];
     let error = null;
@@ -92,6 +99,10 @@ RecommendedArticles.propTypes = {
     return error;
   },
 };
-
+RecommendedArticles.defaultProps = {
+  title: "",
+  calloutLink: "",
+  calloutTitle: "",
+};
 
 export default radium(RecommendedArticles);

--- a/src/components/recommendedArticles/index.jsx
+++ b/src/components/recommendedArticles/index.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { PropTypes } from "react";
 import radium, { Style } from "radium";
 import { media } from "../../../settings.json";
 import { gutter } from "../../utils/grid";
@@ -6,103 +6,98 @@ import Heading from "../heading";
 import CalloutLink from "../calloutLink";
 import ArticlePreview from "../articlePreview";
 
-function RecommendedArticles({ title, calloutLink, calloutTitle, children }) {
-  const styles = {
-    container: {
+const styles = {
+  header: {
+    marginBottom: "43px",
+  },
+
+  heading: {
+    fontSize: "28px",
+    fontWeight: 100,
+    lineHeight: 1,
+  },
+
+  articles: {
+    [`@media (min-width: ${media.min["600"]})`]: {
+      display: "flex",
     },
+  },
 
-    childrenContainer: {
-      marginTop: "43px",
+  footer: {
+    marginTop: "39px",
+  },
+};
 
-      [`@media (min-width: ${media.min["600"]})`]: {
-        display: "flex",
-      },
-    },
-
-    heading: {
-      fontSize: "28px",
-      fontWeight: 100,
-      lineHeight: 1,
-    },
-
-    footer: {
-      marginTop: "39px",
-    },
-  };
-
-  return (
-    <section className="RecommendedArticles" style={styles.container}>
-      <Style
-        scopeSelector=".RecommendedArticles"
-        rules={{
-          mediaQueries: {
-            [`(max-width: ${media.max["600"]})`]: {
-              ".ArticlePreview + .ArticlePreview": {
-                marginTop: gutter("static"),
-              },
-            },
-
-            [`(min-width: ${media.min["600"]})`]: {
-              ".ArticlePreview + .ArticlePreview": {
-                marginLeft: gutter("static"),
-              },
+const RecommendedArticles = ({ articles, heading, calloutHref, calloutLabel, style }) => (
+  <section className="RecommendedArticles" style={style}>
+    <Style
+      scopeSelector=".RecommendedArticles"
+      rules={{
+        mediaQueries: {
+          [`(max-width: ${media.max["600"]})`]: {
+            ".ArticlePreview + .ArticlePreview": {
+              marginTop: gutter("static"),
             },
           },
-        }}
-      />
 
-      {title &&
-      <header>
+          [`(min-width: ${media.min["600"]})`]: {
+            ".ArticlePreview + .ArticlePreview": {
+              marginLeft: gutter("static"),
+            },
+          },
+        },
+      }}
+    />
+
+    {heading &&
+      <header style={styles.header}>
         <Heading
           level={2}
           weight="thin"
           override={styles.heading}
         >
-          {title}
+          {heading}
         </Heading>
       </header>
-      }
+    }
 
-      <div style={styles.childrenContainer}>
-        {children}
-      </div>
+    <div style={styles.articles}>
+      {articles.map((preview, index) => (
+        <ArticlePreview
+          title={preview.title}
+          paragraph={preview.paragraph}
+          image={preview.image}
+          href={preview.href}
+          category={preview.category}
+          categoryHref={preview.categoryHref}
+          key={index}
+        />
+      ))}
+    </div>
 
-      {calloutTitle && calloutLink &&
+    {calloutLabel && calloutHref &&
       <footer style={styles.footer}>
-        <CalloutLink href={calloutLink}>
-          {calloutTitle}
+        <CalloutLink href={calloutHref}>
+          {calloutLabel}
         </CalloutLink>
       </footer>
-      }
-    </section>
-  );
-}
+    }
+  </section>
+);
 
 RecommendedArticles.propTypes = {
-  title: React.PropTypes.string,
-  calloutLink: React.PropTypes.string,
-  calloutTitle: React.PropTypes.string,
-  children: (props, propName, componentName) => {
-    const prop = props[propName];
-    let error = null;
-
-    React.Children.forEach(prop, (child) => {
-      if (child.type !== ArticlePreview) {
-        error = new Error(`${componentName} children should be of type "ArticlePreview".`);
-      }
-
-      if (child.type === ArticlePreview && React.Children.count.length > 2) {
-        error = new Error(`${componentName} should have no more than 2 children.`);
-      }
-    });
-
-    return error;
-  },
-};
-RecommendedArticles.defaultProps = {
-  title: "",
-  calloutLink: "",
-  calloutTitle: "",
+  articles: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string,
+    paragraph: PropTypes.string,
+    image: PropTypes.string,
+    href: PropTypes.string,
+    category: PropTypes.string,
+    categoryHref: PropTypes.string,
+  })).isRequired,
+  heading: PropTypes.string,
+  calloutLabel: PropTypes.string,
+  calloutHref: PropTypes.string,
+  style: PropTypes.objectOf(PropTypes.object),
 };
 
 export default radium(RecommendedArticles);

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -1057,7 +1057,7 @@ storiesOf("Recommended articles", module)
   .addDecorator(withKnobs)
   .add("Default", () => (
     <StyleRoot>
-      <RecommendedArticles>
+      <RecommendedArticles title="Recommended Articles" calloutTitle="More recommendations" calloutLink="/category/recommended">
         <ArticlePreview
           title="New York’s most iconic buildings reimagined on deserted streets"
           paragraph={`A new exhibition in New York of the city’s most iconic

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -1057,29 +1057,33 @@ storiesOf("Recommended articles", module)
   .addDecorator(withKnobs)
   .add("Default", () => (
     <StyleRoot>
-      <RecommendedArticles title="Recommended Articles" calloutTitle="More recommendations" calloutLink="/category/recommended">
-        <ArticlePreview
-          title="New York’s most iconic buildings reimagined on deserted streets"
-          paragraph={`A new exhibition in New York of the city’s most iconic
-            buildings shows them in a new light, with the bustle of modern life
-            stripped out. Photographer`}
-          image="http://placehold.it/410x230"
-          href="/"
-          category="Art and culture"
-          categoryHref="/"
-        />
-
-        <ArticlePreview
-          title="Pull up a seat for David Attenborough’s Planet Earth II"
-          paragraph={`Ten years after the BBC series, Planet Earth, captivated a
-            global audience of over half a billion people, Planet Earth II is
-            coming to our TV screens, narrated once`}
-          image="http://placehold.it/410x230"
-          href="/"
-          category="Wildlife and nature"
-          categoryHref="/"
-        />
-      </RecommendedArticles>
+      <RecommendedArticles
+        heading={text("heading", "Recommended articles")}
+        calloutLabel={text("Callout label", "More recommendations")}
+        calloutHref={text("Callout URL", "/category/recommended")}
+        articles={array("Articles", [
+          {
+            title: "New York’s most iconic buildings reimagined on deserted streets",
+            paragraph: `A new exhibition in New York of the city’s most iconic
+              buildings shows them in a new light, with the bustle of modern life
+              stripped out. Photographer`,
+            image: "http://placehold.it/410x230",
+            href: "/",
+            category: "Art and culture",
+            categoryHref: "/",
+          },
+          {
+            title: "Pull up a seat for David Attenborough’s Planet Earth II",
+            paragraph: `Ten years after the BBC series, Planet Earth, captivated a
+              global audience of over half a billion people, Planet Earth II is
+              coming to our TV screens, narrated once`,
+            image: "http://placehold.it/410x230",
+            href: "/",
+            category: "Wildlife and nature",
+            categoryHref: "/",
+          },
+        ])}
+      />
     </StyleRoot>
   ));
 


### PR DESCRIPTION
- Add props: `heading`, `calloutLabel`, `calloutHref `, `style`
- Replace `children` prop with `articles` prop; now an array of objects can be passed in to define ArticlePreview, rather than having to know that ArticlePreview itself should be passed as children