### PR TITLE
Add lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf dist && mkdir -p dist/components && babel -d dist src",
     "ci": "rm -rf dist && mkdir -p dist/components && babel --watch -d dist src",
     "test:ci": "NODE_ENV=test mocha --reporter spec --compilers js:babel-register --watch --recursive spec/",
+    "lint": "./node_modules/.bin/eslint src --ext .js,.jsx",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "gh-pages": "npm run build-storybook -- -o _gh-pages && gh-pages -d _gh-pages && rm -rf _gh-pages",


### PR DESCRIPTION
I'll be adding the pre-commit in another pull request. It's just that there are a few lint errors that need fixed up before the pre-commit hook can be pushed to master. I wanted to get the lint script in there so at least it can be done manually for now.