### PR TITLE
remove min height restrictions from masthead slider

### DIFF
--- a/src/components/mastheadSlider/index.jsx
+++ b/src/components/mastheadSlider/index.jsx
@@ -63,12 +63,8 @@ export const rules = {
 
 const styles = {
   slide: {
-    minHeight: "400px",
     width: "100%",
     position: "absolute",
-    [`@media (min-width: ${media.min["720"]})`]: {
-      minHeight: "800px",
-    },
   },
   // REM units being used to match what is currently in rizz-next
   isUnderGlobalHeader: {


### PR DESCRIPTION
min height was placing content off the visible slide