### PR TITLE
update spotlight zone positioning

### DIFF
--- a/src/components/spotlightZone/index.jsx
+++ b/src/components/spotlightZone/index.jsx
@@ -116,16 +116,18 @@ const styles = {
 
   zone: {
     fontSize: "16px",
+    top: "32px",
+    position: "absolute",
     fontWeight: settings.typography.fontWeightSemibold,
     lineHeight: 1,
 
     [`@media (min-width: ${settings.media.min["600"]})`]: {
       fontSize: "24px",
+      top: "64px",
     },
 
     [`@media (min-width: ${settings.media.min["960"]})`]: {
-      position: "relative",
-      top: "-147px",
+      top: "80px",
     },
   },
 


### PR DESCRIPTION
fixes https://github.com/lonelyplanet/dotcom-video/issues/97
changes zone text to be absolutely positioned from the top opposed to a large negative top margin which was pushing the text out of view at times. 

