### PR TITLE
Add hover scale effect to CoverPhoto

### DIFF
--- a/src/components/card/card.jsx
+++ b/src/components/card/card.jsx
@@ -11,6 +11,10 @@ const hoverStyles = {
   ".Heading": {
     color: `${color.blue} !important`,
   },
+
+  ".CoverPhoto": {
+    transform: "scale(1.03) !important",
+  },
 };
 
 const styles = {

--- a/src/components/card/cardHeading.jsx
+++ b/src/components/card/cardHeading.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import radium from "radium";
 import Heading from "../heading";
-import { media } from "../../../settings.json";
+import { media, timing } from "../../../settings.json";
 import propTypes from "../../utils/propTypes";
 
 const mq = `@media (max-width: ${media.max["768"]})`;
@@ -13,6 +13,7 @@ const styles = {
   maxHeight: "60px",
   overflow: "hidden",
   textOverflow: "ellipsis",
+  transition: `color ${timing.fast} ease-in-out`,
   WebkitBoxOrient: "vertical",
   WebkitLineClamp: 2,
 

--- a/src/components/card/cardImage.jsx
+++ b/src/components/card/cardImage.jsx
@@ -6,11 +6,16 @@ import propTypes from "../../utils/propTypes";
 
 const styles = {
   container: {
+    overflow: "hidden",
     position: "relative",
   },
 
   anchor: {
     display: "block",
+  },
+
+  coverPhoto: {
+    transition: `transform ${timing.slow} ease-in-out`,
   },
 };
 
@@ -53,10 +58,7 @@ const CardImage = ({
           height={imageSizes[aspectRatio].height}
           style={[
             styles.coverPhoto,
-            opacity && {
-              opacity,
-              transition: `opacity ${timing.default} ease-in-out`,
-            },
+            { opacity },
           ]}
         />
       }

--- a/src/components/thumbnailListItem/index.jsx
+++ b/src/components/thumbnailListItem/index.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import radium from "radium";
+import radium, { Style } from "radium";
 import { Link } from "react-router";
 import { color, timing, typography, zIndex } from "../../../settings.json";
 import font from "../../utils/font";
@@ -11,6 +11,12 @@ import TextBubble from "../textBubble";
 import Heading from "../heading";
 import Icon from "../icon";
 import CoverPhoto from "../coverPhoto";
+
+const hoverStyles = {
+  ".CoverPhoto": {
+    transform: "scale(1.03) !important",
+  },
+};
 
 const styles = {
   container: {
@@ -25,8 +31,14 @@ const styles = {
   imageAnchor: {
     backgroundColor: color.black,
     display: "block",
+    overflow: "hidden",
     position: "relative",
     width: "100%",
+  },
+
+  coverPhoto: {
+    opacity: 0.88,
+    transition: `transform ${timing.slow} ease-in-out`,
   },
 
   imageText: {
@@ -120,6 +132,11 @@ const ThumbnailListItem = ({
       style,
     ]}
   >
+    <Style
+      scopeSelector=".ListItem-thumbnail:hover"
+      rules={hoverStyles}
+    />
+
     <div style={styles.image}>
       <Link
         to={href}
@@ -130,7 +147,7 @@ const ThumbnailListItem = ({
           src={imagePath}
           width={116}
           height={64}
-          style={{ opacity: 0.88 }}
+          style={styles.coverPhoto}
         />
 
         {runtime &&

--- a/src/components/tileVideoPoster/index.jsx
+++ b/src/components/tileVideoPoster/index.jsx
@@ -8,7 +8,7 @@ import {
   CardText,
 } from "../card";
 import Heading from "../heading";
-import { media } from "../../../settings.json";
+import { media, timing } from "../../../settings.json";
 import propTypes from "../../utils/propTypes";
 
 const mq = `@media (max-width: ${media.max["768"]})`;
@@ -35,6 +35,7 @@ const styles = {
     maxHeight: "60px",
     overflow: "hidden",
     textOverflow: "ellipsis",
+    transition: `color ${timing.fast} ease-in-out`,
     WebkitBoxOrient: "vertical",
     WebkitLineClamp: 2,
 


### PR DESCRIPTION
In card, tile and list item components, the CoverPhoto scales slightly when hovered