### PR TITLE
fix prop type warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "color": "^0.11.3",
     "haversine": "^1.0.1",
     "humanize-duration": "^3.10.0",
-    "is-url-external": "^1.0.2",
     "jquery": "^3.1.1",
     "leaflet": "^1.0.1",
     "lodash": "^4.16.6",

--- a/src/components/card/cardAnchor.jsx
+++ b/src/components/card/cardAnchor.jsx
@@ -62,7 +62,7 @@ CardAnchor.propTypes = {
   style: propTypes.style,
 };
 
-CardAnchor.propTypes = {
+CardAnchor.defaultProps = {
   layout: "card",
 };
 

--- a/src/components/cardShelfVideoSwiper/index.jsx
+++ b/src/components/cardShelfVideoSwiper/index.jsx
@@ -7,9 +7,6 @@ import {
   CardShelf,
   CardShelfHeader,
 } from "../cardShelf";
-import CardVideo from "../cardVideo";
-import TileVideo from "../tileVideo";
-import TileVideoPoster from "../tileVideoPoster";
 import PaginatorButton from "../paginatorButton";
 import propTypes from "../../utils/propTypes";
 
@@ -296,18 +293,7 @@ class CardShelfVideoSwiper extends Component {
 }
 
 CardShelfVideoSwiper.propTypes = {
-  children: (props, propName, componentName) => {
-    const prop = props[propName];
-    let error = null;
-
-    React.Children.forEach(prop, (child) => {
-      if (child.type !== CardVideo || child.type !== TileVideo || child.type !== TileVideoPoster) {
-        error = new Error(`${componentName} children should be of type "CardVideo", "TileVideo" or "TileVideoPoster".`);
-      }
-    });
-
-    return error;
-  },
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
   heading: PropTypes.string,
   href: PropTypes.string,
   slidesVisible: PropTypes.oneOf([3, 4]),
@@ -318,6 +304,7 @@ CardShelfVideoSwiper.propTypes = {
       PropTypes.bool,
       PropTypes.element,
       PropTypes.object,
+      PropTypes.array,
     ]),
   ),
   style: propTypes.style,

--- a/src/components/cardVideo/index.jsx
+++ b/src/components/cardVideo/index.jsx
@@ -151,7 +151,7 @@ CardVideo.propTypes = {
     "milliseconds",
   ]),
   heading: PropTypes.string.isRequired,
-  bullets: PropTypes.arrayOf(PropTypes.string).isRequired,
+  bullets: PropTypes.arrayOf(PropTypes.string),
   layout: PropTypes.oneOf([
     "card",
     "tile",

--- a/src/components/gradientOverlay/index.jsx
+++ b/src/components/gradientOverlay/index.jsx
@@ -50,7 +50,7 @@ const GradientOverlay = ({ children, gradientType, color, style }) => {
 
 GradientOverlay.propTypes = {
   color: PropTypes.string.isRequired,
-  children: PropTypes.element.isRequired,
+  children: PropTypes.element,
   gradientType: PropTypes.oneOf([
     "",
     "linear",

--- a/src/components/heading/index.jsx
+++ b/src/components/heading/index.jsx
@@ -3,6 +3,7 @@ import radium from "radium";
 import settings from "../../../settings.json";
 import { rgb } from "../../utils/color";
 import font from "../../utils/font";
+import propTypes from "../../utils/propTypes";
 
 const styles = {
   base: {
@@ -226,9 +227,7 @@ Heading.propTypes = {
   /**
    * Override styles
    */
-  override: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-  ]),
+  override: propTypes.style,
 };
 
 Heading.defaultProps = {

--- a/src/components/heroImageContainer/index.jsx
+++ b/src/components/heroImageContainer/index.jsx
@@ -34,7 +34,7 @@ HeroImageContainer.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
-  ]).isRequired,
+  ]),
   imagePath: PropTypes.string.isRequired,
   style: PropTypes.objectOf(PropTypes.object),
 };

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from "react";
 import { Link as RouterLink } from "react-router";
-import isExternal from "is-url-external";
+
+const isExternal = (url) => /^(http|https):\/\//.test(url);
 
 const Link = (props) => (
   isExternal(props.to) ?

--- a/src/components/mastheadSlider/index.jsx
+++ b/src/components/mastheadSlider/index.jsx
@@ -130,6 +130,7 @@ MastheadSlider.propTypes = {
     PropTypes.number,
     PropTypes.bool,
     PropTypes.object,
+    PropTypes.array,
   ])),
   customSettings: PropTypes.objectOf(PropTypes.oneOfType([
     PropTypes.string,

--- a/src/components/newsArticleAuthor/index.jsx
+++ b/src/components/newsArticleAuthor/index.jsx
@@ -42,13 +42,14 @@ const NewsArticleAuthor = ({ name, title, absoluteTime, relativeTime, theme, sty
         (theme === "dark") && { color: color.white },
       ]}
     />
-
-    <Timestamp
-      dateTime={absoluteTime}
-      style={styles.timestamp}
-    >
-      {relativeTime}
-    </Timestamp>
+    {relativeTime &&
+      <Timestamp
+        dateTime={absoluteTime}
+        style={styles.timestamp}
+      >
+        {relativeTime}
+      </Timestamp>
+    }
   </div>
 );
 

--- a/src/components/sectionHeader/index.jsx
+++ b/src/components/sectionHeader/index.jsx
@@ -70,7 +70,7 @@ const SectionHeader = ({ children, heading, theme, style }) => {
 
 SectionHeader.propTypes = {
   children: PropTypes.node.isRequired,
-  heading: PropTypes.shape(Heading.propTypes).isRequired,
+  heading: PropTypes.shape(Heading.propTypes),
   theme: React.PropTypes.oneOf([
     "default",
     "light",

--- a/src/components/tallCarousel/index.jsx
+++ b/src/components/tallCarousel/index.jsx
@@ -114,12 +114,14 @@ TallCarousel.propTypes = {
     PropTypes.number,
     PropTypes.bool,
     PropTypes.object,
+    PropTypes.array,
   ])),
   customSettings: PropTypes.objectOf(PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
     PropTypes.bool,
     PropTypes.object,
+    PropTypes.array,
   ])),
 };
 

--- a/src/components/tileVideo/index.jsx
+++ b/src/components/tileVideo/index.jsx
@@ -5,11 +5,14 @@ import CardVideo from "../cardVideo";
 const TileVideo = (props) => (
   <CardVideo
     {...props}
-    aspectRatio="video"
-    layout="tile"
   />
 );
 
 TileVideo.propTypes = CardVideo.propTypes;
+
+TileVideo.defaultProps = {
+  aspectRatio: "video",
+  layout: "tile",
+};
 
 export default radium(TileVideo);

--- a/src/components/typeSelector/index.jsx
+++ b/src/components/typeSelector/index.jsx
@@ -252,7 +252,7 @@ TypeSelector.propTypes = {
   /**
    * Menu Items for Type Selector
    */
-  menuItems: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
+  menuItems: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
 
   /**
    * Method to run when the Link component is clicked


### PR DESCRIPTION
fixes propType warnings

*had to remove the specific components allowed to be children of the `CarShelfVideoSwiper` component due to the fact that these components are wrapped in a Radium connector and were not registering as the underlying component