### PR TITLE
Make Radium a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "truncate": "^2.0.0"
   },
   "peerDependencies": {
+    "radium": "^0.19.0",
     "react": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This will help to fix errors `Invalid context ‘_radiumStyleKeeper’ of
type ‘StyleKeeper’` in apps that use Backpack