### PR TITLE
Create text components to match typography styles

### DIFF
--- a/src/components/text/index.jsx
+++ b/src/components/text/index.jsx
@@ -1,0 +1,6 @@
+export Heading from "./textHeading";
+export TextAccent from "./textAccent";
+export TextBodyArticle from "./textBodyArticle";
+export TextBodySmall from "./textBodySmall";
+export TextHeading from "./textHeading";
+export TextUppercase from "./textUppercase";

--- a/src/components/text/textAccent.jsx
+++ b/src/components/text/textAccent.jsx
@@ -1,0 +1,24 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import colors from "../../styles/colors";
+import { textAccent } from "../../utils/typography";
+import propTypes from "../../utils/propTypes";
+
+const styles = Object.assign({}, {
+  color: colors.textPrimary,
+  marginBottom: 0,
+  marginTop: 0,
+}, textAccent());
+
+const TextAccent = ({ children, style }) => (
+  <p style={[styles, style]}>
+    {children}
+  </p>
+);
+
+TextAccent.propTypes = {
+  children: PropTypes.string.isRequired,
+  style: propTypes.style,
+};
+
+export default radium(TextAccent);

--- a/src/components/text/textBodyArticle.jsx
+++ b/src/components/text/textBodyArticle.jsx
@@ -1,0 +1,24 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import colors from "../../styles/colors";
+import { textBodyArticle } from "../../utils/typography";
+import propTypes from "../../utils/propTypes";
+
+const styles = Object.assign({}, {
+  color: colors.textPrimary,
+  marginBottom: 0,
+  marginTop: 0,
+}, textBodyArticle());
+
+const TextBodyArticle = ({ children, style }) => (
+  <p style={[styles, style]}>
+    {children}
+  </p>
+);
+
+TextBodyArticle.propTypes = {
+  children: PropTypes.string.isRequired,
+  style: propTypes.style,
+};
+
+export default radium(TextBodyArticle);

--- a/src/components/text/textBodySmall.jsx
+++ b/src/components/text/textBodySmall.jsx
@@ -1,0 +1,24 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import colors from "../../styles/colors";
+import { textBodySmall } from "../../utils/typography";
+import propTypes from "../../utils/propTypes";
+
+const styles = Object.assign({}, {
+  color: colors.textPrimary,
+  marginBottom: 0,
+  marginTop: 0,
+}, textBodySmall());
+
+const TextBodySmall = ({ children, style }) => (
+  <p style={[styles, style]}>
+    {children}
+  </p>
+);
+
+TextBodySmall.propTypes = {
+  children: PropTypes.string.isRequired,
+  style: propTypes.style,
+};
+
+export default radium(TextBodySmall);

--- a/src/components/text/textHeading.jsx
+++ b/src/components/text/textHeading.jsx
@@ -1,0 +1,63 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import colors from "../../styles/colors";
+import {
+  textHeading1,
+  textHeading2,
+  textHeading3,
+  textHeading4,
+  textHeading5,
+  textHeading6,
+} from "../../utils/typography";
+import propTypes from "../../utils/propTypes";
+
+function Heading({
+  children,
+  level,
+  size,
+  weight,
+  style,
+}) {
+  const Element = `h${level}`;
+
+  const styles = {
+    1: textHeading1(weight),
+    2: textHeading2(weight),
+    3: textHeading3(weight),
+    4: textHeading4(weight),
+    5: textHeading5(weight),
+    6: textHeading6(weight),
+  };
+
+  return (
+    <Element
+      style={[
+        {
+          color: colors.textPrimary,
+          marginTop: 0,
+          marginBottom: 0,
+        },
+        styles[size],
+        style,
+      ]}
+    >
+      {children}
+    </Element>
+  );
+}
+
+Heading.propTypes = {
+  children: PropTypes.node.isRequired,
+  level: propTypes.heading,
+  size: propTypes.heading,
+  weight: propTypes.fontWeight,
+  style: propTypes.style,
+};
+
+Heading.defaultProps = {
+  level: 2,
+  size: 2,
+  weight: "book",
+};
+
+export default radium(Heading);

--- a/src/components/text/textUppercase.jsx
+++ b/src/components/text/textUppercase.jsx
@@ -1,0 +1,24 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import colors from "../../styles/colors";
+import { textUppercase } from "../../utils/typography";
+import propTypes from "../../utils/propTypes";
+
+const styles = Object.assign({}, {
+  color: colors.textPrimary,
+  marginBottom: 0,
+  marginTop: 0,
+}, textUppercase());
+
+const TextUppercase = ({ children, style }) => (
+  <p style={[styles, style]}>
+    {children}
+  </p>
+);
+
+TextUppercase.propTypes = {
+  children: PropTypes.string.isRequired,
+  style: propTypes.style,
+};
+
+export default radium(TextUppercase);

--- a/src/utils/propTypes.js
+++ b/src/utils/propTypes.js
@@ -1,6 +1,12 @@
 import { PropTypes } from "react";
 
 export default {
+  heading: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+  fontWeight: PropTypes.oneOf([
+    "light",
+    "book",
+    "medium",
+  ]),
   style: PropTypes.objectOf(
     PropTypes.oneOfType([
       PropTypes.string,

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -121,10 +121,11 @@ import StaticMap from "../src/components/staticMap";
 import Strapline from "../src/components/strapline";
 import TabbedNav from "../src/components/tabbedNav";
 import Tag from "../src/components/tag";
-import TallCarousel from "../src/components/tallCarousel";
 import TagList from "../src/components/tagList";
-import TextBubble from "../src/components/textBubble";
 // Takeover
+import TallCarousel from "../src/components/tallCarousel";
+import { TextAccent, TextBodyArticle, TextBodySmall, TextHeading, TextUppercase } from "../src/components/text";
+import TextBubble from "../src/components/textBubble";
 import ThumbnailListItem from "../src/components/thumbnailListItem";
 import TileGrid from "../src/components/tileGrid";
 import TileVideo from "../src/components/tileVideo";
@@ -1841,6 +1842,50 @@ storiesOf("Tall Carousel", module)
         image: "https://lonelyplanetimages.imgix.net/a/g/hi/t/57c5143d7297c21181c522eee9e3b05e-europe.jpg?h=768&sharp=10&vib=20",
       }]}
     />
+  ));
+
+storiesOf("Text", module)
+  .addDecorator(withKnobs)
+  .add("Accent", () => (
+    <TextAccent>
+      {text("Text", "Lorem ipsum dolor sit amet")}
+    </TextAccent>
+  ))
+  .add("Body article", () => (
+    <TextBodyArticle>
+      {text("Text", `Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. Aenean sed
+        mauris sit amet massa interdum bibendum.
+        Ut ac ex leo. Cras blandit enim ut metus
+        feugiat, vitae pharetra massa aliquet.`)}
+    </TextBodyArticle>
+  ))
+  .add("Body small", () => (
+    <TextBodySmall>
+      {text("Text", `Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. Aenean sed
+        mauris sit amet massa interdum bibendum.
+        Ut ac ex leo. Cras blandit enim ut metus
+        feugiat, vitae pharetra massa aliquet.`)}
+    </TextBodySmall>
+  ))
+  .add("Heading", () => (
+    <TextHeading
+      level={select("Level", [1, 2, 3, 4, 5, 6], 2)}
+      size={select("Size", [1, 2, 3, 4, 5, 6], 2)}
+      weight={select("Weight", {
+        light: "Light",
+        book: "Book",
+        medium: "Medium",
+      }, "book")}
+    >
+      {text("Text", "Lorem ipsum")}
+    </TextHeading>
+  ))
+  .add("Uppercase", () => (
+    <TextUppercase>
+      {text("Text", "Lorem ipsum")}
+    </TextUppercase>
   ));
 
 storiesOf("Text bubble", module)


### PR DESCRIPTION
These components map to styles/typography and use utils/typography to apply the styles.

TextHeading is a stripped down version of Heading and the idea is to deprecate Heading in a future release. TextHeading was created 1) somewhat as an experiment to simplify Heading and 2) as to not break every implementation of Heading currently in use.