### PR TITLE
update: responsive masthead and slide styles

### DIFF
--- a/src/components/mastheadSlider/index.jsx
+++ b/src/components/mastheadSlider/index.jsx
@@ -62,9 +62,20 @@ export const rules = {
 };
 
 const styles = {
+  slideContainer: {
+    overflowY: "hidden",
+    minHeight: "370px",
+    [`@media (min-width: ${media.min["720"]})`]: {
+      minHeight: "650px",
+    },
+  },
   slide: {
     width: "100%",
     position: "absolute",
+    minHeight: "370px",
+    [`@media (min-width: ${media.min["720"]})`]: {
+      minHeight: "650px",
+    },
   },
   // REM units being used to match what is currently in rizz-next
   isUnderGlobalHeader: {
@@ -95,10 +106,13 @@ class MastheadSlider extends Component {
     return (
       <div
         className="MastheadSlider"
-        style={[isUnderGlobalHeader && styles.isUnderGlobalHeader, {
-          height: this.props.height,
-          overflowY: "hidden",
-        }]}
+        style={[
+          styles.slideContainer,
+          isUnderGlobalHeader && styles.isUnderGlobalHeader,
+          {
+            height: this.props.height,
+          },
+        ]}
       >
         <Style
           scopeSelector=".MastheadSlider"

--- a/src/components/slide/index.jsx
+++ b/src/components/slide/index.jsx
@@ -47,6 +47,7 @@ const styles = {
       fontSize: "calc(11px + 5vw)",
     },
     [`@media (min-width: ${media.min["720"]})`]: {
+      fontSize: "60px",
       marginBottom: "40px",
     },
     [`@media (min-width: ${media.min["840"]})`]: {
@@ -87,6 +88,9 @@ const styles = {
       justifyContent: "center",
       alignItems: "center",
       [`@media (min-width: ${media.min["720"]})`]: {
+        width: "68%",
+      },
+      [`@media (min-width: ${media.min["1290"]})`]: {
         width: "50%",
       },
     },


### PR DESCRIPTION
content was overflowing the main nav when content was too long or window was too short
this adds min height and lets the content expand responsively

reference https://github.com/lonelyplanet/dotcom-video/issues/177 