### PR TITLE
update: pass full ad id through as prop and hide by default

### DIFF
--- a/src/components/slide/index.jsx
+++ b/src/components/slide/index.jsx
@@ -32,6 +32,8 @@ const styles = {
     },
   },
   adContainer: {
+    // ad container will get display: block inline if present through GTM
+    display: "none",
     marginBottom: "36px",
     [`@media (min-width: ${media.min["720"]})`]: {
       marginBottom: "56px",
@@ -173,7 +175,7 @@ const Slide = ({
 
         {adPosition &&
           <div
-            id={`video-home-sponsor-advert-${adPosition}`}
+            id={adPosition}
             style={styles.adContainer}
           />
         }


### PR DESCRIPTION
GTM will update the style attribute of the div with the targeted ad id. We can hide this div by default and let GTM take care of the rest. 

Also this passes in the entire id since this slide component may not only be used for video slides. 