### PR TITLE
Hide first cloned slide

### DIFF
--- a/src/components/mastheadSlider/index.jsx
+++ b/src/components/mastheadSlider/index.jsx
@@ -59,6 +59,9 @@ export const rules = {
   },
   ".slick-slider": { display: "none" },
   ".slick-slider.slick-initialized,.slick-slide:first-child": { display: "block" },
+  ".slick-cloned:first-of-type": {
+    display: "none !important",
+  },
 };
 
 const styles = {


### PR DESCRIPTION
Fixes a bug where the first cloned slide, which is actually the last
slide, can sometimes appear while the slider is still loading.