### PR TITLE
Prevent ArticlePaginationItem image from stretching

### DIFF
--- a/src/components/articlePaginationItem/index.jsx
+++ b/src/components/articlePaginationItem/index.jsx
@@ -60,6 +60,7 @@ const styles = {
     display: "block",
     height: "100%",
     left: 0,
+    objectFit: "cover",
     opacity: 0.4,
     position: "absolute",
     top: 0,


### PR DESCRIPTION
Use object-fit CSS property on the img element