### PR TITLE
update border colors on components used in travel news

### DIFF
--- a/src/components/calloutLink/index.jsx
+++ b/src/components/calloutLink/index.jsx
@@ -6,6 +6,7 @@ import { rgb } from "../../utils/color";
 import { blueLink, outline } from "../../utils/mixins";
 import font from "../../utils/font";
 import { ChevronRight } from "../icon";
+import colors from "../../styles/colors";
 
 const styles = {
   container: {
@@ -15,7 +16,7 @@ const styles = {
   },
 
   border: {
-    backgroundColor: `rgba(${rgb(color.lightBlue)}, .3)`,
+    backgroundColor: `${colors.borderPrimary}`,
     height: "1px",
     marginBottom: "11px",
     width: "calc(100% + 64px)",

--- a/src/components/listContainer/index.jsx
+++ b/src/components/listContainer/index.jsx
@@ -1,18 +1,18 @@
 import React, { PropTypes } from "react";
 import radium, { Style } from "radium";
 import cn from "classnames";
-import { color, media } from "../../../settings.json";
-import { rgb } from "../../utils/color";
+import mq from "../../styles/mq";
+import colors from "../../styles/colors";
 
 const styles = {
   ".ListItemContainer:not(:last-of-type)": {
-    borderBottom: `1px solid rgba(${rgb(color.lightBlue)}, .3)`,
+    borderBottom: `1px solid ${colors.borderPrimary}`,
     marginBottom: "40px",
     paddingBottom: "40px",
   },
 
   mediaQueries: {
-    [`(min-width: ${media.min["720"]})`]: {
+    [`(min-width: ${mq.min["720"]})`]: {
       ".ListItemContainer:not(:last-of-type)": {
         marginBottom: "48px",
         paddingBottom: "48px",


### PR DESCRIPTION
update border colors on components used in travel news, these will use new backpack colors instead of rizzo-next colors