### PR TITLE
Create navigation components

### DIFF
--- a/src/components/navigation/index.jsx
+++ b/src/components/navigation/index.jsx
@@ -1,0 +1,2 @@
+export Navigation from "./navigation";
+export NavigationTab from "./navigationTab";

--- a/src/components/navigation/navigation.jsx
+++ b/src/components/navigation/navigation.jsx
@@ -1,0 +1,74 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import Container from "../container";
+import colors from "../../styles/colors";
+import zIndex from "../../styles/zIndex";
+import propTypes from "../../utils/propTypes";
+
+const styles = {
+  nav: {
+    backgroundColor: colors.bgPrimary,
+    position: "relative",
+    textAlign: "center",
+    transform: "translateZ(0)",
+    zIndex: zIndex.globalHeader,
+  },
+
+  container: {
+    borderBottom: `1px solid ${colors.borderPrimary}`,
+    overflow: "hidden",
+  },
+
+  scroller: {
+    overflowX: "auto",
+    overflowY: "hidden",
+    whiteSpace: "nowrap",
+  },
+};
+
+const Navigation = (props) => {
+  const { children, height, sticky, style, ...properties } = props;
+
+  return (
+    <nav
+      className="Navigation"
+      style={[
+        styles.nav,
+        sticky && { position: "sticky", top: 0 },
+        style,
+      ]}
+      {...properties}
+    >
+      <Container
+        style={[
+          styles.container,
+          { height: `${(height + 1)}px` },
+        ]}
+      >
+        <div
+          style={[
+            styles.scroller,
+            { height: `${(height + 15)}px` },
+          ]}
+        >
+          <div style={{ height: `${height}px` }}>
+            {children}
+          </div>
+        </div>
+      </Container>
+    </nav>
+  );
+};
+
+Navigation.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.node).isRequired,
+  height: PropTypes.number,
+  sticky: PropTypes.bool,
+  style: propTypes.style,
+};
+
+Navigation.defaultProps = {
+  height: 80,
+};
+
+export default radium(Navigation);

--- a/src/components/navigation/navigationTab.jsx
+++ b/src/components/navigation/navigationTab.jsx
@@ -1,0 +1,66 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import colors from "../../styles/colors";
+import timing from "../../styles/timing";
+import { fontWeightMedium } from "../../styles/typography";
+import { textUppercase } from "../../utils/typography";
+import propTypes from "../../utils/propTypes";
+
+const styles = Object.assign({}, {
+  backgroundColor: colors.bgPrimary,
+  borderBottomColor: colors.bgPrimary,
+  borderBottomStyle: "solid",
+  borderBottomWidth: "4px",
+  color: colors.textPrimary,
+  cursor: "pointer",
+  display: "inline-block",
+  fontWeight: fontWeightMedium,
+  height: "100%",
+  paddingLeft: "16px",
+  paddingRight: "16px",
+  paddingTop: "4px", // offset border width, keep text centered
+  textAlign: "center",
+  transition: `border-bottom-color ${timing.fast} ease-in-out,
+    color ${timing.fast} ease-in-out`,
+  verticalAlign: "middle",
+
+  ":hover": {
+    color: colors.textSecondary,
+  },
+
+  ":active": {
+    color: colors.textSecondary,
+  },
+
+  ":focus": {
+    color: colors.linkPrimary,
+  },
+}, textUppercase());
+
+const NavigationTab = (props) => {
+  const { children, onClick, active, style, ...properties } = props;
+
+  return (
+    <button
+      className="NavigationTab"
+      onClick={onClick}
+      style={[
+        styles,
+        active && { borderBottomColor: colors.linkPrimary },
+        style,
+      ]}
+      {...properties}
+    >
+      {children}
+    </button>
+  );
+};
+
+NavigationTab.propTypes = {
+  children: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
+  active: PropTypes.bool,
+  style: propTypes.style,
+};
+
+export default radium(NavigationTab);

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -85,6 +85,7 @@ import MastheadSlider from "../src/components/mastheadSlider";
 import Modal from "../src/components/modal";
 import MoreLink from "../src/components/moreLink";
 import Narrative from "../src/components/narrative";
+import { Navigation, NavigationTab } from "../src/components/navigation";
 import NewsArticleAuthor from "../src/components/newsArticleAuthor";
 import NewsList from "../src/components/newsList";
 import Newsletter from "../src/components/newsletter";
@@ -1153,6 +1154,22 @@ storiesOf("More link", module)
     >
       {text("Text", "View all tours")}
     </MoreLink>
+  ));
+
+storiesOf("Navigation", module)
+  .addDecorator(withKnobs)
+  .add("Default", () => (
+    <Navigation height={number("Height", 80)} sticky={boolean("Sticky", false)}>
+      <NavigationTab active={boolean("Active", true)} onClick={action("Experiences tab clicked")}>
+        {text("Text", "Experiences")}
+      </NavigationTab>
+
+      <NavigationTab onClick={action("Map tab clicked")}>Map</NavigationTab>
+      <NavigationTab onClick={action("Articles tab clicked")}>Articles</NavigationTab>
+      <NavigationTab onClick={action("Interests tab clicked")}>Interests</NavigationTab>
+      <NavigationTab onClick={action("Books tab clicked")}>Books</NavigationTab>
+      <NavigationTab onClick={action("Adventures tab clicked")}>Adventures</NavigationTab>
+    </Navigation>
   ));
 
 storiesOf("Narrative", module)


### PR DESCRIPTION
The goal of this PR is to simplify and standardize navigation components. Eventually these components will be used to deprecate TabbedNav and SectionalNav components as this was essentially a rewrite of those components in order to make the navigation more reusable.