### PR TITLE
update: pass through all props to input/textarea

### DIFF
--- a/src/components/form/input.jsx
+++ b/src/components/form/input.jsx
@@ -2,24 +2,18 @@ import React from "react";
 import radium from "radium";
 import styles from "./styles";
 
-function Input({
-  type,
-  id,
-  label,
-  name,
-  defaultValue,
-  value,
-  error,
-  min,
-  max,
-  placeholder,
-  required,
-  size,
-  theme,
-  fill,
-  customStyles,
-  onChange,
-}) {
+function Input(props) {
+  const {
+    label,
+    name,
+    id,
+    type,
+    error,
+    size,
+    theme,
+    fill,
+    customStyles,
+  } = props;
   const style = [styles.base];
 
   style.push(styles.element.input.base);
@@ -46,25 +40,16 @@ function Input({
     style.push(customStyles);
   }
 
-  const props = {
-    style,
-    type,
-    id,
-    value,
-    name: name || id,
-  };
-
-  props.defaultValue = defaultValue || null;
-  props.placeholder = placeholder || null;
-  props.required = required || null;
-
-  if (type === "number") {
-    props.min = min;
-    props.max = max;
-  }
 
   return (
-    <input {...props} aria-label={label} title={label} onChange={onChange} />
+    <input
+      name={name || id}
+      aria-label={label}
+      title={label}
+      type={type}
+      {...props}
+      style={style}
+    />
   );
 }
 
@@ -90,19 +75,8 @@ Input.propTypes = {
 
   name: React.PropTypes.string,
 
-  defaultValue: React.PropTypes.string,
-
-  value: React.PropTypes.string,
 
   error: React.PropTypes.bool,
-
-  min: React.PropTypes.string,
-
-  max: React.PropTypes.string,
-
-  placeholder: React.PropTypes.string,
-
-  required: React.PropTypes.bool,
 
   size: React.PropTypes.oneOf([
     "tiny",
@@ -133,7 +107,6 @@ Input.propTypes = {
     ]),
   ),
 
-  onChange: React.PropTypes.func,
 };
 
 Input.defaultProps = {
@@ -145,16 +118,6 @@ Input.defaultProps = {
 
   name: "",
 
-  defaultValue: "",
-
-  min: "",
-
-  max: "",
-
-  placeholder: "",
-
-  required: false,
-
   size: "medium",
 
   theme: "base",
@@ -163,7 +126,6 @@ Input.defaultProps = {
 
   customStyles: null,
 
-  onChange: null,
 };
 
 Input.styles = styles;

--- a/src/components/form/textarea.jsx
+++ b/src/components/form/textarea.jsx
@@ -3,21 +3,15 @@ import radium from "radium";
 import styles from "./styles";
 import propTypes from "../../utils/propTypes";
 
-function TextArea({
-  id,
-  label,
-  name,
-  value,
-  placeholder,
-  required,
-  rows,
-  cols,
-  size,
-  theme,
-  onChange,
-  customStyles,
-  maxLength,
-}) {
+function TextArea(props) {
+  const {
+    id,
+    label,
+    name,
+    size,
+    theme,
+    customStyles,
+  } = props;
   const style = [styles.base];
 
   style.push(styles.element.textarea.base);
@@ -38,18 +32,11 @@ function TextArea({
 
   return (
     <textarea
-      style={style}
-      id={id}
       name={name || id}
-      value={value}
-      placeholder={placeholder}
-      rows={rows}
-      cols={cols}
-      required={required}
-      onChange={onChange}
       aria-label={label}
       title={label}
-      maxLength={maxLength}
+      {...props}
+      style={style}
     />
   );
 }
@@ -60,16 +47,6 @@ TextArea.propTypes = {
   label: React.PropTypes.string.isRequired,
 
   name: React.PropTypes.string,
-
-  value: React.PropTypes.string,
-
-  placeholder: React.PropTypes.string,
-
-  required: React.PropTypes.bool,
-
-  rows: React.PropTypes.number,
-
-  cols: React.PropTypes.number,
 
   size: React.PropTypes.oneOf([
     "tiny",
@@ -86,11 +63,9 @@ TextArea.propTypes = {
     "float",
   ]),
 
-  onChange: React.PropTypes.func,
 
   customStyles: propTypes.style,
 
-  maxLength: React.PropTypes.string,
 };
 
 TextArea.defaultProps = {
@@ -99,7 +74,6 @@ TextArea.defaultProps = {
   label: "",
 
   name: "",
-
 
   placeholder: "",
 


### PR DESCRIPTION
instead of passing specific props through to the input component, I spread all props onto the input. 
This is so we can just add any field that may be on an input without having to define it. 
I pulled off any styles from props to maintain the current way that these components are styled