### PR TITLE
update: expose uploaded avatr image

### DIFF
--- a/src/components/avatarUpload/index.jsx
+++ b/src/components/avatarUpload/index.jsx
@@ -79,6 +79,9 @@ class AvatarUpload extends Component {
         this.setState({
           src: e.target.result,
         });
+        if (typeof this.props.exposeImageOnChange === "function") {
+          this.props.exposeImageOnChange(e.target.result);
+        }
       };
 
       reader.readAsDataURL(this.input.files[0]);
@@ -128,6 +131,7 @@ class AvatarUpload extends Component {
 AvatarUpload.propTypes = {
   src: PropTypes.string.isRequired,
   style: propTypes.style,
+  exposeImageOnChange: PropTypes.func,
 };
 
 export default radium(AvatarUpload);


### PR DESCRIPTION
adds a function to the avatarUpload to pass out the newly uploaded image data. 
This way we will be able to pass the new image data out to Open Planet to save in profile