### PR TITLE
Prevent double Twitter pop-up window

### DIFF
--- a/src/components/socialShareContainer/index.jsx
+++ b/src/components/socialShareContainer/index.jsx
@@ -67,12 +67,12 @@ class SocialShareContainer extends Component {
 
   static openWindow(event) {
     const { windowOptions, windowSize } = SocialShareContainer.windowSettings();
+    const isFacebook = event.currentTarget.dataset.network === "facebook";
+    const isReddit = event.currentTarget.dataset.network === "reddit";
+    const isTwitter = event.currentTarget.dataset.network === "twitter";
+    const shouldOpenWindow = isFacebook || isReddit || isTwitter;
 
-    if (
-      event.currentTarget.dataset.network === "facebook" ||
-      event.currentTarget.dataset.network === "reddit" ||
-      event.currentTarget.dataset.network === "twitter"
-    ) {
+    if (shouldOpenWindow) {
       window.open(
         event.currentTarget.href,
         "share",

--- a/src/components/socialShareContainer/index.jsx
+++ b/src/components/socialShareContainer/index.jsx
@@ -70,7 +70,11 @@ class SocialShareContainer extends Component {
     const isFacebook = event.currentTarget.dataset.network === "facebook";
     const isReddit = event.currentTarget.dataset.network === "reddit";
     const isTwitter = event.currentTarget.dataset.network === "twitter";
-    const shouldOpenWindow = isFacebook || isReddit || isTwitter;
+    const hasTwitterWidgets = typeof window !== "undefined" &&
+      typeof window.__twttr !== "undefined" &&
+      window.__twttr.widgets &&
+      window.__twttr.widgets.init;
+    const shouldOpenWindow = isFacebook || isReddit || (isTwitter && !hasTwitterWidgets);
 
     if (shouldOpenWindow) {
       window.open(

--- a/src/components/socialShareContainer/index.jsx
+++ b/src/components/socialShareContainer/index.jsx
@@ -82,11 +82,9 @@ class SocialShareContainer extends Component {
         "share",
         `${windowOptions},${windowSize}`
       );
-    } else {
-      window.location = event.currentTarget.href;
-    }
 
-    event.preventDefault();
+      event.preventDefault();
+    }
   }
 
   constructor() {


### PR DESCRIPTION
An issue was discovered when Twitter's widgets JS is loaded onto a page where the SocialShare component is used.

From https://dev.twitter.com/web/intents

> Twitter’s widgets JavaScript will automatically handle creating child windows at the appropriate dimensions and firing appropriate JavaScript events when included on a webpage. We recommend rendering each web intent at 550px by 420px if you create your own web intent handlers.

This caused two pop-up windows to appear when the Twitter share button was clicked; one from the `window.open` function in SocialShareContainer and the second from Twitter's widget.

The solution I came up with was to check to see if the `window.__twttr` object was loaded on the page. When the widgets JS is loaded, it will create this object. I'm not sure if this is the most reliable way to handle this, so if there is a better way, please let me know.

Referenced in this issue: https://github.com/lonelyplanet/wp-travelnews-frontend/issues/234