### PR TITLE
Check for child in Tabs

### DIFF
--- a/src/components/tabs/tabs.jsx
+++ b/src/components/tabs/tabs.jsx
@@ -44,7 +44,7 @@ class Tabs extends Component {
     }
 
     Children.forEach(this.props.children, (child, index) => {
-      if (child.props.active) {
+      if (child && child.props.active) {
         selectedIndex = index;
       }
     });


### PR DESCRIPTION
If `child` is null or undefined then `child.props` gives an error