### PR TITLE
fix: reorder social login props to not override styles

### DIFF
--- a/src/components/socialLoginButton/index.jsx
+++ b/src/components/socialLoginButton/index.jsx
@@ -67,12 +67,12 @@ const SocialLoginButton = (props) => {
 
   return (
     <button
+      {...props}
       style={[
         styles.button,
         style,
       ]}
       onClick={onClick}
-      {...props}
     >
       {iconFromString(iconName, iconParameters)}
       {children}


### PR DESCRIPTION
style prop was getting passed directly on component so it cause the socialButton styles to be wiped away