### PR TITLE
Install standard-version module

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,18 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "gh-pages": "npm run build-storybook -- -o _gh-pages && gh-pages -d _gh-pages && rm -rf _gh-pages",
-    "tag": "git tag v$npm_package_version",
-    "version:patch": "npm --no-git-tag-version version patch",
-    "version:minor": "npm --no-git-tag-version version minor",
-    "version:major": "npm --no-git-tag-version version major",
-    "preversion": "npm run test && npm run check-changelog && npm run check-only-changelog-changed",
-    "postversion": "git commit package.json CHANGELOG.md -m \"Version $npm_package_version\" && npm run tag && git push && git push --tags && npm publish",
+    "version": "npm run release --commit-all",
+    "version:patch": "npm run release -- --release-as patch",
+    "version:minor": "npm run release -- --release-as minor",
+    "version:major": "npm run release -- --release-as major",
+    "push": "git push --follow-tags origin master && npm publish",
+    "deploy": "npm run version && npm run push",
+    "deploy:patch": "npm run version:patch && npm run push",
+    "deploy:minor": "npm run version:minor && npm run push",
+    "deploy:major": "npm run version:major && npm run push",
+    "preversion": "npm run test && npm run lint && npm run build",
     "prepublish": "npm run build",
-    "postpublish": "npm run gh-pages",
-    "check-changelog": "expr $(git status --porcelain 2>/dev/null| grep \"^\\s*M.*CHANGELOG.md\" | wc -l) >/dev/null || (echo 'Please edit CHANGELOG.md' && exit 1)",
-    "check-only-changelog-changed": "(expr $(git status --porcelain 2>/dev/null| grep -v \"CHANGELOG.md\" | wc -l) >/dev/null && echo 'Only CHANGELOG.md may have uncommitted changes' && exit 1) || exit 0"
+    "postpublish": "npm run gh-pages"
   },
   "pre-commit": [
     "lint"
@@ -84,6 +86,7 @@
     "mocha": "^3.0.2",
     "pre-commit": "^1.2.2",
     "react-addons-shallow-compare": "^15.0.2",
-    "sinon": "^1.17.6"
+    "sinon": "^1.17.6",
+    "standard-version": "^4.0.0"
   }
 }


### PR DESCRIPTION
standard-version is used to help with automatic CHANGELOG
generation and publishing to npm. It replaces the scripts
that were used to help manually generate the CHANGELOG.

The available commands are as follows:

- `version`: Considered the "default" command to create a
new release, this command will automatically decide which
version number to bump (patch, minor, major) and will
require a manual push and publish
- `version:patch`: This command bypasses the automated
version bump and allows you to force a patch release
- `version:minor`: This command bypasses the automated
version bump and allows you to force a minor release
- `version:major`: This command bypasses the automated
version bump and allows you to force a major release
- `push`: This command is an alias to push and publish if you
use one of the `version` commands
- `deploy`: If you want to release, push and publish all at
once, you can run this command. It works in the same way as
- `version` in that it will automatically bump the version but
it will also run the `push` command afterwards
- `deploy:patch`: Automatically push and publish after
creating a patch release
- `deploy:minor`: Automatically push and publish after
creating a minor release
- `deploy:major`: Automatically push and publish after
creating a major release

Closes #173