### PR TITLE
Add new values for z-index

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -174,6 +174,12 @@
     "globalHeader": 100,
     "mapHolderOpen": 200,
     "videoOverlayClose": 1000,
-    "modal": 9999
+    "popup": 4000,
+    "dialog": 5000,
+    "dropdown": 6000,
+    "overlay": 7000,
+    "menu": 8000,
+    "modal": 9000,
+    "toast": 10000
   }
 }

--- a/src/styles/zIndex.js
+++ b/src/styles/zIndex.js
@@ -2,11 +2,19 @@ export default {
   auto: "auto",
   below: -1,
   default: 1,
+  popup: 4000,
+  dialog: 5000,
+  dropdown: 6000,
+  overlay: 7000,
+  menu: 8000,
+  modal: 9000,
+  toast: 10000,
+
+  // TODO: Deprecate legacy z-index values
   slideshowSlide: 3,
   middle: 10,
   top: 20,
   globalHeader: 100,
   mapHolderOpen: 200,
   videoOverlayClose: 1000,
-  modal: 9999,
 };


### PR DESCRIPTION
There needs to be more variation and intention with the z-index values.
Currently, many components use “modal” and then add or subtract values
to place the component on the desired layer. The addition of the global
log in modal has revealed that this method for setting z-index is not
very sustainable. Essentially, “modal” doesn’t mean much at this point
because too many components that aren’t a modal use it.

The goal here is to introduce some hierarchy within the z-index values.
Every component that sits on top of the page should not use “modal” or
“modal + 1”, because when an actual modal is rendered now, it may or
may not be placed on top of every other component. The stacking order
of components should be clearly defined and this should help.