### PR TITLE
Add media query to disable motion in Toast

### DIFF
--- a/src/components/toast/index.jsx
+++ b/src/components/toast/index.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from "react";
-import radium from "radium";
+import radium, { Style } from "radium";
 import colors from "../../styles/colors";
 import timing from "../../styles/timing";
 import { fontWeightMedium, fontSizeUppercase } from "../../styles/typography";
@@ -58,10 +58,22 @@ const Toast = ({ children, color, icon, direction, visible, style }) => (
       style,
     ]}
   >
+    <Style
+      scopeSelector=".Toast"
+      rules={{
+        mediaQueries: {
+          "(prefers-reduced-motion)": {
+            transform: "translateY(0) !important",
+          },
+        },
+      }}
+    />
+
     {icon && iconFromString(icon, {
       style: styles.icon,
       ariaHidden: true,
     })}
+
     {children}
   </div>
 );


### PR DESCRIPTION
As an accessibility concern, if the use has requested to
reduce motion via macOS or iOS, then the `prefers-reduced-motion`
media query will disable sliding in movement.

More on this topic: https://webkit.org/blog/7551/responsive-design-for-motion/