### PR TITLE
Set default href and role in Button to null

### DIFF
--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -193,7 +193,7 @@ function Button({
   customStyles,
 }) {
   const Element = href ? "a" : "button";
-  const role = Element === "a" ? "button" : "";
+  const role = Element === "a" ? "button" : null;
 
   const style = [
     styles.base,
@@ -298,7 +298,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
-  href: "",
+  href: null,
 
   onClick: null,
 


### PR DESCRIPTION
This prevents the props from being applied to the element.
In the case of `href`, it would apply `href(unknown)` to the
element.