### PR TITLE
Add "gray" to Button color prop validation

### DIFF
--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -246,6 +246,7 @@ Button.propTypes = {
   color: React.PropTypes.oneOf([
     "blue",
     "white",
+    "gray",
     "transparent",
   ]),
 


### PR DESCRIPTION
Prevents error in console about invalid value on `color` prop.