### PR TITLE
Remove references to deprecated book font weight

### DIFF
--- a/spec/utils/typography.spec.js
+++ b/spec/utils/typography.spec.js
@@ -20,7 +20,7 @@ const baseStyles = {
 };
 
 describe("Text heading 1", () => {
-  it("should add text heading 1 styles with default weight book", () => {
+  it("should add text heading 1 styles with default weight regular", () => {
     const styles = Object.assign({}, baseStyles, textHeading1());
 
     expect(styles).to.deep.equal({
@@ -58,7 +58,7 @@ describe("Text heading 1", () => {
 });
 
 describe("Text heading 2", () => {
-  it("should add text heading 2 styles with default weight book", () => {
+  it("should add text heading 2 styles with default weight regular", () => {
     const styles = Object.assign({}, baseStyles, textHeading2());
 
     expect(styles).to.deep.equal({
@@ -96,7 +96,7 @@ describe("Text heading 2", () => {
 });
 
 describe("Text heading 3", () => {
-  it("should add text heading 3 styles with default weight book", () => {
+  it("should add text heading 3 styles with default weight regular", () => {
     const styles = Object.assign({}, baseStyles, textHeading3());
 
     expect(styles).to.deep.equal({
@@ -134,7 +134,7 @@ describe("Text heading 3", () => {
 });
 
 describe("Text heading 4", () => {
-  it("should add text heading 4 styles with default weight book", () => {
+  it("should add text heading 4 styles with default weight regular", () => {
     const styles = Object.assign({}, baseStyles, textHeading4());
 
     expect(styles).to.deep.equal({
@@ -172,7 +172,7 @@ describe("Text heading 4", () => {
 });
 
 describe("Text heading 5", () => {
-  it("should add text heading 5 styles with default weight book", () => {
+  it("should add text heading 5 styles with default weight regular", () => {
     const styles = Object.assign({}, baseStyles, textHeading5());
 
     expect(styles).to.deep.equal({
@@ -210,7 +210,7 @@ describe("Text heading 5", () => {
 });
 
 describe("Text heading 6", () => {
-  it("should add text heading 6 styles with default weight book", () => {
+  it("should add text heading 6 styles with default weight regular", () => {
     const styles = Object.assign({}, baseStyles, textHeading6());
 
     expect(styles).to.deep.equal({
@@ -248,7 +248,7 @@ describe("Text heading 6", () => {
 });
 
 describe("Text heading 7", () => {
-  it("should add text heading 7 styles with default weight book", () => {
+  it("should add text heading 7 styles with default weight regular", () => {
     const styles = Object.assign({}, baseStyles, textHeading7());
 
     expect(styles).to.deep.equal({
@@ -286,7 +286,7 @@ describe("Text heading 7", () => {
 });
 
 describe("Text heading 8", () => {
-  it("should add text heading 8 styles with default weight book", () => {
+  it("should add text heading 8 styles with default weight regular", () => {
     const styles = Object.assign({}, baseStyles, textHeading8());
 
     expect(styles).to.deep.equal({

--- a/src/styles/typography.js
+++ b/src/styles/typography.js
@@ -1,8 +1,6 @@
 export const fontWeightLight = 300;
 export const fontWeightRegular = 500;
 export const fontWeightMedium = 600;
-// Book is deprecated and will be removed in the next major release
-export const fontWeightBook = fontWeightRegular;
 
 export const fontSizeSuper = 88;
 export const fontSizeHeading1 = 64;

--- a/src/utils/propTypes.js
+++ b/src/utils/propTypes.js
@@ -6,7 +6,6 @@ export default {
     "light",
     "regular",
     "medium",
-    "book", // Book is deprecated and will be removed in the next major release
   ]),
   style: PropTypes.objectOf(
     PropTypes.oneOfType([

--- a/src/utils/typography.js
+++ b/src/utils/typography.js
@@ -37,7 +37,6 @@ const weights = {
   light: fontWeightLight,
   regular: fontWeightRegular,
   medium: fontWeightMedium,
-  book: fontWeightRegular, // Book is deprecated and will be removed in the next major release
 };
 
 export function textSuper() {


### PR DESCRIPTION
BREAKING CHANGE: Book version of Benton Sans has been removed

Closes #251 