### PR TITLE
Delete content prop from Lede

### DIFF
--- a/src/components/lede/index.jsx
+++ b/src/components/lede/index.jsx
@@ -20,14 +20,14 @@ const styles = {
   },
 };
 
-function Lede({ children, content, style }) {
+function Lede({ children, style }) {
   return (
     <div
       className="Lede"
       style={[styles.container, style]}
     >
       <p style={styles.paragraph}>
-        {children || content}
+        {children}
       </p>
     </div>
   );
@@ -35,7 +35,6 @@ function Lede({ children, content, style }) {
 
 Lede.propTypes = {
   children: PropTypes.string.isRequired,
-  content: PropTypes.string,
   style: propTypes.style,
 };
 

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -975,8 +975,8 @@ storiesOf("Italic text", module)
 storiesOf("Lede", module)
   .addDecorator(withKnobs)
   .add("Default", () => (
-    <Lede
-      content={text("Text", `Lorem ipsum dolor sit amet, consectetur
+    <Lede>
+      {text("Text", `Lorem ipsum dolor sit amet, consectetur
         adipiscing elit, sed do eiusmod tempor incididunt
         ut labore et dolore magna aliqua. Ut enim ad minim
         veniam, quis nostrud exercitation ullamco laboris
@@ -986,7 +986,7 @@ storiesOf("Lede", module)
         Excepteur sint occaecat cupidatat non proident,
         sunt in culpa qui officia deserunt mollit anim id
         est laborum`)}
-    />
+    </Lede>
   ));
 
 storiesOf("List item (news)", module)


### PR DESCRIPTION
BREAKING CHANGE: `content` prop has been replaced with `children`

Closes #208 