### PR TITLE
Create Auth components

### DIFF
--- a/src/components/auth/README.md
+++ b/src/components/auth/README.md
@@ -1,0 +1,31 @@
+# Auth
+
+Auth components can be combined to create the UI for logging into
+lonelyplanet.com. Some components are just wrappers of other components
+with some extra styling (i.e., `AuthDisclaimer`, `AuthEmailLink`). These
+components serve a very specific purpose and therefore shouldn't be used
+on their own.
+
+### Example usage
+
+```jsx
+<AuthContainer hasLogo>
+  <AuthMessage>
+    Organize your research & unlock
+    tools like bookmarking.
+  </AuthMessage>
+
+  <AuthSocialButtons
+    actions={authActions()}
+  />
+
+  <AuthEmailLink
+    onClick={(event) => {
+      event.preventDefault();
+      authActions().passwordless();
+    }}
+  />
+
+  <AuthDisclaimer> ... </AuthDisclaimer>
+</AuthContainer>
+```

--- a/src/components/auth/authContainer.jsx
+++ b/src/components/auth/authContainer.jsx
@@ -1,0 +1,48 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import Logo from "../logo";
+import propTypes from "../../utils/propTypes";
+
+const styles = {
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+
+  logo: {
+    marginBottom: "16px",
+    width: "160px",
+  },
+
+  content: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+};
+
+const AuthContainer = ({ children, hasLogo, style }) => (
+  <div
+    className="AuthContainer"
+    style={[styles.container, style]}
+  >
+    {hasLogo &&
+      <Logo style={styles.logo} />
+    }
+
+    <div style={styles.content}>
+      {children}
+    </div>
+  </div>
+);
+
+AuthContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+  hasLogo: PropTypes.bool,
+  style: propTypes.style,
+};
+
+export default radium(AuthContainer);

--- a/src/components/auth/authDisclaimer.jsx
+++ b/src/components/auth/authDisclaimer.jsx
@@ -1,0 +1,21 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import propTypes from "../../utils/propTypes";
+import DisclaimerText from "../disclaimerText";
+
+const styles = {
+  marginTop: "24px",
+};
+
+const AuthDisclaimer = ({ children, style }) => (
+  <DisclaimerText style={[styles, style]}>
+    {children}
+  </DisclaimerText>
+);
+
+AuthDisclaimer.propTypes = {
+  children: PropTypes.node,
+  style: propTypes.style,
+};
+
+export default radium(AuthDisclaimer);

--- a/src/components/auth/authEmailLink.jsx
+++ b/src/components/auth/authEmailLink.jsx
@@ -1,0 +1,29 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import MoreLink from "../moreLink";
+import propTypes from "../../utils/propTypes";
+
+const styles = {
+  moreLink: {
+    letterSpacing: 0,
+    padding: "16px",
+  },
+};
+
+const AuthEmailLink = ({ onClick, style }) => (
+  <MoreLink
+    caps
+    size="small"
+    style={[style, styles.moreLink]}
+    onClick={onClick}
+  >
+    Sign in or sign up with email
+  </MoreLink>
+);
+
+AuthEmailLink.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  style: propTypes.style,
+};
+
+export default radium(AuthEmailLink);

--- a/src/components/auth/authMessage.jsx
+++ b/src/components/auth/authMessage.jsx
@@ -1,0 +1,53 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import { Heading } from "../../components/text";
+import { textHeading7 } from "../../utils/typography";
+import propTypes from "../../utils/propTypes";
+
+const styles = {
+  container: Object.assign({}, {
+    maxWidth: "295px",
+    width: "100%",
+    marginBottom: "40px",
+    textAlign: "center",
+  }, textHeading7()),
+
+  heading: {
+    marginBottom: "16px",
+  },
+
+  text: {
+    margin: 0,
+    padding: 0,
+  },
+};
+
+const AuthMessage = ({ children, title, style }) => (
+  <div
+    className="AuthMessage"
+    style={[styles.container, style]}
+  >
+    {title &&
+      <Heading
+        level={6}
+        size={6}
+        weight="medium"
+        style={styles.heading}
+      >
+        {title}
+      </Heading>
+    }
+
+    <p style={styles.text}>
+      {children}
+    </p>
+  </div>
+);
+
+AuthMessage.propTypes = {
+  children: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  style: propTypes.style,
+};
+
+export default radium(AuthMessage);

--- a/src/components/auth/authSocialButtons.jsx
+++ b/src/components/auth/authSocialButtons.jsx
@@ -1,0 +1,51 @@
+import React, { PropTypes } from "react";
+import radium from "radium";
+import SocialLoginButton from "../socialLoginButton";
+import propTypes from "../../utils/propTypes";
+
+const styles = {
+  spacing: {
+    marginBottom: "16px",
+  },
+};
+
+const AuthSocialButtons = ({ actions, style }) => (
+  <div
+    className="AuthSocialButtons"
+    style={[styles.spacing, style]}
+  >
+    <SocialLoginButton
+      style={styles.spacing}
+      iconName="FacebookBlockColor"
+      onClick={actions.facebook}
+    >
+      Continue with Facebook
+    </SocialLoginButton>
+
+    <SocialLoginButton
+      style={styles.spacing}
+      iconName="TwitterColor"
+      onClick={actions.twitter}
+    >
+      Continue with Twitter
+    </SocialLoginButton>
+
+    <SocialLoginButton
+      iconName="GoogleColor"
+      onClick={actions.google}
+    >
+      Continue with Google
+    </SocialLoginButton>
+  </div>
+);
+
+AuthSocialButtons.propTypes = {
+  actions: PropTypes.shape({
+    facebook: PropTypes.func,
+    twitter: PropTypes.func,
+    google: PropTypes.func,
+  }).isRequired,
+  style: propTypes.style,
+};
+
+export default radium(AuthSocialButtons);

--- a/src/components/auth/index.js
+++ b/src/components/auth/index.js
@@ -1,0 +1,5 @@
+export AuthSocialButtons from "./authSocialButtons";
+export AuthContainer from "./authContainer";
+export AuthDisclaimer from "./authDisclaimer";
+export AuthEmailLink from "./authEmailLink";
+export AuthMessage from "./authMessage";


### PR DESCRIPTION
Auth components can be combined to create the UI for logging into
lonelyplanet.com. Some components are just wrappers of other components
with some extra styling (i.e., `AuthDisclaimer`, `AuthEmailLink`). These
components serve a very specific purpose and therefore shouldn't be used
on their own.

Deprecates ModalContentSocialAuth component