### PR TITLE
Add component to center components in storybook

### DIFF
--- a/stories/center.jsx
+++ b/stories/center.jsx
@@ -1,0 +1,40 @@
+import React, { PropTypes } from "react";
+
+const Center = ({ children, backgroundColor, grow, shrink, basis }) => (
+  <div
+    style={{
+      alignItems: "center",
+      backgroundColor,
+      display: "flex",
+      height: "100vh",
+      justifyContent: "center",
+      padding: "32px",
+      width: "100%",
+    }}
+  >
+    {React.cloneElement(children, {
+      style: {
+        flexGrow: grow ? 1 : 0,
+        flexShrink: shrink ? 1 : 0,
+        flexBasis: basis,
+      },
+    })}
+  </div>
+);
+
+Center.propTypes = {
+  children: PropTypes.element.isRequired,
+  backgroundColor: PropTypes.string,
+  grow: PropTypes.bool,
+  shrink: PropTypes.bool,
+  basis: PropTypes.string,
+};
+
+Center.defaultProps = {
+  backgroundColor: "#f4fbfe",
+  grow: false,
+  shrink: false,
+  basis: "auto",
+};
+
+export default Center;


### PR DESCRIPTION
The Center component uses flexbox to center a component
horizontally and vertically within Storybook’s display area.

You can pass in an optional background color as well as
flexbox properties to control how the child component grows
and shrinks.

It can be used simply by wrapping a component in
stories/index.jsx like so:

```
<Center>
  <Avatar />
</Center>
```