### PR TITLE
Reorder storybook addon imports

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,3 +1,3 @@
+import "@storybook/addon-knobs/register";
 import "@storybook/addon-actions/register";
 import "@storybook/addon-links/register";
-import "@storybook/addon-knobs/register";


### PR DESCRIPTION
This is so that the "knobs" tab shows first in the UI since
it is the most commonly used.