### PR TITLE
Updated spotlightZone to allow HTML within its paragraph property value

### DIFF
--- a/src/components/spotlightZone/index.jsx
+++ b/src/components/spotlightZone/index.jsx
@@ -278,8 +278,9 @@ const SpotlightZone = ({
           {title}
         </Heading>
 
-        <p style={styles.paragraph}>
-          {paragraph}
+        <p
+          style={styles.paragraph}
+          dangerouslySetInnerHTML={{ __html: paragraph }}>
         </p>
 
         {adSlot && <hr style={styles.divider} /> }


### PR DESCRIPTION
Before:
<img width="1018" alt="screen shot 2017-06-16 at 3 06 16 pm" src="https://user-images.githubusercontent.com/3586751/27241190-c199be82-52a5-11e7-81c5-b6c055ccdb15.png">

After:
<img width="756" alt="screen shot 2017-06-16 at 3 07 54 pm" src="https://user-images.githubusercontent.com/3586751/27241199-c7e36838-52a5-11e7-9351-4f0d748b9114.png">

