### PR TITLE
Create Typeahead component

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-slick": "0.14.4",
     "react-stickynode": "^1.2.1",
     "react-tether": "^0.5.2",
+    "react-typeahead": "git://github.com/thomasthesecond/react-typeahead.git#refactor",
     "react-validate-form": "^1.0.3",
     "react-waypoint": "^5.0.3",
     "truncate": "^2.0.0"
@@ -75,6 +76,10 @@
     "react": "^15.0.0"
   },
   "devDependencies": {
+    "@storybook/addon-actions": "^3.0.0",
+    "@storybook/addon-knobs": "^3.0.0",
+    "@storybook/addon-links": "^3.0.0",
+    "@storybook/react": "^3.0.1",
     "babel-cli": "^6.14.0",
     "babel-eslint": "^6.1.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
@@ -92,10 +97,6 @@
     "pre-commit": "^1.2.2",
     "react-addons-shallow-compare": "^15.0.2",
     "sinon": "^1.17.6",
-    "standard-version": "^4.0.0",
-    "@storybook/react": "^3.0.1",
-    "@storybook/addon-actions": "^3.0.0",
-    "@storybook/addon-knobs": "^3.0.0",
-    "@storybook/addon-links": "^3.0.0"
+    "standard-version": "^4.0.0"
   }
 }

--- a/src/components/typeahead/index.jsx
+++ b/src/components/typeahead/index.jsx
@@ -1,0 +1,177 @@
+import React, { PropTypes } from "react";
+import radium, { Style } from "radium";
+import TypeaheadComponent from "react-typeahead/dist/typeahead";
+import TokenizerComponent from "react-typeahead/dist/tokenizer";
+import colors from "../../styles/colors";
+import timing from "../../styles/timing";
+import {
+  fontWeightLight,
+  fontWeightRegular,
+  fontSizeBodySmall,
+  fontSizeHeading7,
+  lineHeightHeading7,
+  lineHeightReset,
+} from "../../styles/typography";
+import { outline } from "../../utils/mixins";
+import { rgba } from "../../utils/color";
+import font from "../../utils/font";
+import propTypes from "../../utils/propTypes";
+
+const Typeahead = ({
+  options,
+  placeholder,
+  useTokens,
+  style,
+}) => (
+  <div>
+    <Style
+      rules={{
+        ".Typeahead": {
+          backgroundColor: colors.bgPrimary,
+          color: colors.textPrimary,
+          fontFamily: font("benton"),
+          fontSize: `${fontSizeHeading7}px`,
+          lineHeight: lineHeightReset,
+          position: "relative",
+        },
+
+        ".Typeahead-dropdown": {
+          boxShadow: `0 5px 10px 1px ${rgba("#99a9b3", 0.5)}`,
+          left: 0,
+          listStyle: "none",
+          marginBottom: 0,
+          marginTop: 0,
+          overflow: "hidden",
+          paddingLeft: 0,
+          position: "absolute",
+          top: "auto",
+          width: "100%",
+        },
+
+        ".Typeahead-option": {
+          fontWeight: fontWeightLight,
+          padding: "12px 4px",
+          whiteSpace: "nowrap",
+        },
+
+        ".Typeahead-option--hover": {
+          backgroundColor: colors.bgSecondary,
+        },
+
+        ".Typeahead-value": {
+          cursor: "default",
+        },
+
+        ".Typeahead-token": {
+          alignItems: "center",
+          backgroundColor: colors.bgPrimary,
+          border: `1px solid ${colors.borderPrimary}`,
+          borderRadius: "32px",
+          display: "inline-flex",
+          color: colors.textPrimary,
+          fontFamily: font("benton"),
+          fontSize: `${fontSizeBodySmall}px`,
+          fontWeight: fontWeightRegular,
+          height: "32px",
+          justifyContent: "center",
+          lineHeight: lineHeightReset,
+          paddingLeft: "24px",
+          paddingRight: "24px",
+          position: "relative",
+        },
+
+        ".Typeahead-tokenDelete": {
+          backgroundColor: "transparent",
+          border: 0,
+          cursor: "pointer",
+          display: "inline-block",
+          fontSize: "8px",
+          lineHeight: lineHeightReset,
+          marginRight: "-8px",
+          padding: "8px",
+          transition: `color ${timing.fast} ease-in-out`,
+        },
+
+        ".Typeahead-tokenDelete:hover": {
+          color: rgba(colors.textPrimary, 0.7),
+        },
+
+        ".Typeahead-tokenDelete:active": {
+          color: rgba(colors.textPrimary, 0.7),
+        },
+
+        ".Typeahead-tokenDelete:focus": {
+          color: rgba(colors.textPrimary, 0.7),
+          outline: 0,
+        },
+
+        ".Typeahead-tokenDelete:focus > svg": outline(),
+
+        ".Typeahead-token:not(:first-of-type)": {
+          marginLeft: "8px",
+        },
+
+        ".Typeahead-input": {
+          backgroundColor: colors.bgPrimary,
+          border: 0,
+          borderBottom: `1px solid ${colors.borderPrimary}`,
+          color: "inherit",
+          display: "block",
+          fontFamily: "inherit",
+          fontSize: "1em",
+          lineHeight: lineHeightHeading7,
+          position: "relative",
+          padding: "16px 4px 15px",
+          transition: `border-bottom-color ${timing.fast} ease-in-out`,
+          width: "100%",
+        },
+
+        ".Typeahead-input:focus": {
+          borderBottomColor: colors.textPrimary,
+          outline: 0,
+        },
+
+        ".Typeahead-input::-webkit-input-placeholder": {
+          color: rgba(colors.textPrimary, 0.3),
+        },
+
+        ".Typeahead-input::-moz-placeholder": {
+          color: rgba(colors.textPrimary, 0.3),
+        },
+
+        ".Typeahead-input:-ms-input-placeholder": {
+          color: rgba(colors.textPrimary, 0.3),
+        },
+
+        ".Typeahead-input:-moz-placeholder": {
+          color: rgba(colors.textPrimary, 0.3),
+        },
+      }}
+    />
+
+    {useTokens &&
+      <TokenizerComponent
+        placeholder={placeholder}
+        options={options}
+        style={style}
+      />
+    }
+
+    {!useTokens &&
+      <TypeaheadComponent
+        placeholder={placeholder}
+        options={options}
+        style={style}
+      />
+    }
+  </div>
+);
+
+Typeahead.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  placeholder: PropTypes.string,
+  useTokens: PropTypes.bool,
+  style: propTypes.style,
+};
+
+export default radium(Typeahead);

--- a/stories/data.json
+++ b/stories/data.json
@@ -257,5 +257,53 @@
         "description": "From the Statue of Liberty to Ground Zero to Chinatown, New York City is full of things to do and see. We recommend spending extra time here; please speak to your sales agent to book extra accommodation. \n\nIncluded Activities:\nDeparture Day"
       }
     ]
-  }
+  },
+
+  "travelInterests": [
+    "Adventure",
+    "Art and architecture",
+    "Backpacking",
+    "Beaches",
+    "Business",
+    "Ecotourism",
+    "Family",
+    "Food",
+    "History",
+    "Locals",
+    "LGBTQ",
+    "Luxury",
+    "Nature",
+    "Nightlife",
+    "Peace and quiet",
+    "Shopping"
+  ],
+
+  "typeaheadPlaces": [
+    "Africa",
+    "Antarctica",
+    "Asia",
+    "Australia & Pacific",
+    "Caribbean",
+    "Central America",
+    "Europe",
+    "Franklin, Tennessee",
+    "Knoxville, Tennessee",
+    "Memphis, Tennessee",
+    "Middle East",
+    "Nashville, Tennessee",
+    "North America",
+    "North Carolina",
+    "North Dakota",
+    "North Horr, Kenya",
+    "North Korea",
+    "Northren Ireland",
+    "South Africa",
+    "South America",
+    "South Carolina",
+    "South Dakota",
+    "South Korea",
+    "South Sudan",
+    "Southwell, England",
+    "Tennessee"
+  ]
 }

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -157,6 +157,7 @@ import Toast from "../src/components/toast";
 import Tooltip from "../src/components/tooltip";
 import TourItinerary from "../src/components/tourItinerary";
 import TravelAlert from "../src/components/travelAlert";
+import Typeahead from "../src/components/typeahead";
 import TypeSelector from "../src/components/typeSelector";
 import VideoEmbed from "../src/components/videoEmbed";
 import WatchLaterModal from "../src/components/watchLater/watchLaterModal";
@@ -2558,6 +2559,22 @@ storiesOf("Travel alert", module)
     <TravelAlert>
       {text("Text", "The US Center for Disease Control <a href=\"http://www.cdc.gov/zika/geo/active-countries.html\">has issued a travel alert suggesting that pregnant women postpone travel to the Bahamas due to the presence of the zika virus</a>.")}
     </TravelAlert>
+  ));
+
+storiesOf("Typeahead", module)
+  .addDecorator(withKnobs)
+  .add("Default", () => (
+    <Typeahead
+      options={data.typeaheadPlaces}
+      placeholder="Select a place to go"
+    />
+  ))
+  .add("Tokenizer", () => (
+    <Typeahead
+      options={data.travelInterests}
+      placeholder="Select your travel interests"
+      useTokens
+    />
   ));
 
 storiesOf("Type selector", module)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@storybook/addon-actions@^3.0.0", "@storybook/addon-actions@^3.0.1":
+"@storybook/addon-actions@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.0.1.tgz#b3832b79c34cc8a73cfe5e7ba808c4dde25241dc"
   dependencies:
@@ -11,6 +11,17 @@
     json-stringify-safe "^5.0.1"
     prop-types "^15.5.8"
     react-inspector "^2.0.0"
+
+"@storybook/addon-actions@^3.0.1", "@storybook/addon-actions@^3.1.2", "@storybook/addon-actions@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.1.6.tgz#0cbf00ede57ff00d1dfe02e554043d6963940064"
+  dependencies:
+    "@storybook/addons" "^3.1.6"
+    deep-equal "^1.0.1"
+    json-stringify-safe "^5.0.1"
+    prop-types "^15.5.8"
+    react-inspector "^2.0.0"
+    uuid "^3.1.0"
 
 "@storybook/addon-knobs@^3.0.0":
   version "3.0.1"
@@ -27,15 +38,41 @@
     react-datetime "^2.8.10"
     react-textarea-autosize "^4.3.0"
 
+"@storybook/addon-knobs@^3.1.2":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.1.6.tgz#ead1e705a778b67c959d93f809c21025e5066123"
+  dependencies:
+    "@storybook/addons" "^3.1.6"
+    babel-runtime "^6.23.0"
+    deep-equal "^1.0.1"
+    global "^4.3.2"
+    insert-css "^1.0.0"
+    lodash.debounce "^4.0.8"
+    moment "^2.18.1"
+    prop-types "^15.5.8"
+    react-color "^2.11.4"
+    react-datetime "^2.8.10"
+    react-textarea-autosize "^4.3.0"
+
 "@storybook/addon-links@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.0.0.tgz#497ae071b9f36f150a47a5c61d0688d615faec0c"
   dependencies:
     "@storybook/addons" "^3.0.0"
 
+"@storybook/addon-links@^3.1.2", "@storybook/addon-links@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.1.6.tgz#62c8a839e54ff0adb04c6023dae467b336ced5d9"
+  dependencies:
+    "@storybook/addons" "^3.1.6"
+
 "@storybook/addons@*", "@storybook/addons@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.0.0.tgz#0a59b73bbea15f927ec439d7bd9e67ef3719a819"
+
+"@storybook/addons@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.1.6.tgz#29ef2348550f5a74d5e83dd75d04714cac751c39"
 
 "@storybook/channel-postmessage@^3.0.0":
   version "3.0.0"
@@ -44,9 +81,21 @@
     "@storybook/channels" "^3.0.0"
     json-stringify-safe "^5.0.1"
 
+"@storybook/channel-postmessage@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-3.1.6.tgz#867768a2ca2efbd796432300fe5e9b834d9c2ca5"
+  dependencies:
+    "@storybook/channels" "^3.1.6"
+    global "^4.3.2"
+    json-stringify-safe "^5.0.1"
+
 "@storybook/channels@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.0.0.tgz#603a1ea4779ee3d0b86d854f0ae6f899958ba73d"
+
+"@storybook/channels@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-3.1.6.tgz#81d61591bf7613dd2bcd81d26da40aeaa2899034"
 
 "@storybook/react-fuzzy@^0.4.0":
   version "0.4.0"
@@ -107,6 +156,59 @@
     webpack-dev-middleware "^1.10.2"
     webpack-hot-middleware "^2.18.0"
 
+"@storybook/react@^3.1.3":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-3.1.6.tgz#9393bb987ff08ee5f49c4557d12eb84377dee5d2"
+  dependencies:
+    "@storybook/addon-actions" "^3.1.6"
+    "@storybook/addon-links" "^3.1.6"
+    "@storybook/addons" "^3.1.6"
+    "@storybook/channel-postmessage" "^3.1.6"
+    "@storybook/ui" "^3.1.6"
+    airbnb-js-shims "^1.1.1"
+    autoprefixer "^7.1.1"
+    babel-core "^6.24.1"
+    babel-loader "^7.0.0"
+    babel-plugin-react-docgen "^1.5.0"
+    babel-preset-es2015 "^6.24.1"
+    babel-preset-es2016 "^6.24.1"
+    babel-preset-react "^6.24.1"
+    babel-preset-react-app "^3.0.0"
+    babel-preset-stage-0 "^6.24.1"
+    babel-runtime "^6.23.0"
+    case-sensitive-paths-webpack-plugin "^2.0.0"
+    chalk "^1.1.3"
+    commander "^2.9.0"
+    common-tags "^1.4.0"
+    configstore "^3.1.0"
+    css-loader "^0.28.1"
+    express "^4.15.3"
+    file-loader "^0.11.1"
+    find-cache-dir "^1.0.0"
+    glamor "^2.20.25"
+    glamorous "^3.22.1"
+    global "^4.3.2"
+    json-loader "^0.5.4"
+    json-stringify-safe "^5.0.1"
+    json5 "^0.5.1"
+    lodash.pick "^4.4.0"
+    postcss-flexbugs-fixes "^3.0.0"
+    postcss-loader "^2.0.5"
+    prop-types "^15.5.10"
+    qs "^6.4.0"
+    react-modal "^1.7.7"
+    redux "^3.6.0"
+    request "^2.81.0"
+    serve-favicon "^2.4.3"
+    shelljs "^0.7.7"
+    style-loader "^0.17.0"
+    url-loader "^0.5.8"
+    util-deprecate "^1.0.2"
+    uuid "^3.0.1"
+    webpack "^2.5.1"
+    webpack-dev-middleware "^1.10.2"
+    webpack-hot-middleware "^2.18.0"
+
 "@storybook/ui@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.0.1.tgz#fbb2dca43bb35ec7d0efd68fb8336478e5e25585"
@@ -116,6 +218,30 @@
     deep-equal "^1.0.1"
     events "^1.1.1"
     fuzzysearch "^1.0.3"
+    json-stringify-safe "^5.0.1"
+    keycode "^2.1.8"
+    lodash.pick "^4.4.0"
+    lodash.sortby "^4.7.0"
+    mantra-core "^1.7.0"
+    podda "^1.2.2"
+    prop-types "^15.5.8"
+    qs "^6.4.0"
+    react-inspector "^2.0.0"
+    react-komposer "^2.0.0"
+    react-modal "^1.7.6"
+    react-split-pane "^0.1.63"
+    redux "^3.6.0"
+
+"@storybook/ui@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-3.1.6.tgz#5d47c6003a2d78c06ede43861089747d986d918e"
+  dependencies:
+    "@storybook/react-fuzzy" "^0.4.0"
+    babel-runtime "^6.23.0"
+    deep-equal "^1.0.1"
+    events "^1.1.1"
+    fuzzysearch "^1.0.3"
+    global "^4.3.2"
     json-stringify-safe "^5.0.1"
     keycode "^2.1.8"
     lodash.pick "^4.4.0"
@@ -658,6 +784,14 @@ babel-plugin-react-docgen@^1.4.2:
     babel-types "^6.16.0"
     lodash "4.x.x"
     react-docgen "^2.12.1"
+
+babel-plugin-react-docgen@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.5.0.tgz#0339717ad51f4a5ce4349330b8266ea5a56f53b4"
+  dependencies:
+    babel-types "^6.24.1"
+    lodash "4.x.x"
+    react-docgen "^2.15.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -1297,6 +1431,10 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+brcast@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/brcast/-/brcast-2.0.0.tgz#9e627ab82209895664c1d6c1f45cd8c43422e3f6"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -1467,6 +1605,17 @@ chai@^3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
+chai@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.0.2.tgz#2f7327c4de6f385dd7787999e2ab02697a32b83b"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^2.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
 chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1476,6 +1625,10 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 chokidar@^1.4.3, chokidar@^1.6.1:
   version "1.6.1"
@@ -1888,11 +2041,19 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2, create-react-class@^15.5.x:
+create-react-class@^15.5.2:
   version "15.5.2"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.5.2.tgz#6a8758348df660b88326a0e764d569f274aad681"
   dependencies:
     fbjs "^0.8.9"
+    object-assign "^4.1.1"
+
+create-react-class@^15.5.x, create-react-class@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
 cross-spawn@^5.0.1:
@@ -2094,6 +2255,12 @@ deep-eql@^0.1.3:
   dependencies:
     type-detect "0.1.1"
 
+deep-eql@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-2.0.2.tgz#b1bac06e56f0a76777686d50c9feb75c2ed7679a"
+  dependencies:
+    type-detect "^3.0.0"
+
 deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -2187,6 +2354,10 @@ doctrine@^2.0.0:
 dom-align@1.x:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.5.3.tgz#b906b616822a5e599f579ec8505e367c51da7588"
+
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
 
 domain-browser@^1.1.1:
   version "1.1.7"
@@ -2610,11 +2781,15 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-memoize@^2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.2.7.tgz#f145c5c22039cedf0a1d4ff6ca592ad0268470ca"
+
 fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
-fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.4, fbjs@^0.8.8, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -2806,6 +2981,10 @@ fuse.js@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.0.4.tgz#cd4e2ec63ac324e28f5d17fcc3d01584379d3717"
 
+fuzzy@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
+
 fuzzysearch@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fuzzysearch/-/fuzzysearch-1.0.3.tgz#dffc80f6d6b04223f2226aa79dd194231096d008"
@@ -2836,6 +3015,10 @@ generate-object-property@^1.1.0:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
 get-pkg-repo@^1.0.0:
   version "1.3.0"
@@ -2914,6 +3097,25 @@ github-url-from-git@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz#f985fedcc0a9aa579dc88d7aff068d55cc6251a0"
 
+glamor@^2.20.25:
+  version "2.20.25"
+  resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.25.tgz#71b84b82b67a9327771ac59de53ee915d148a4a3"
+  dependencies:
+    babel-runtime "^6.18.0"
+    fbjs "^0.8.8"
+    object-assign "^4.1.0"
+    prop-types "^15.5.8"
+
+glamorous@^3.22.1:
+  version "3.23.4"
+  resolved "https://registry.yarnpkg.com/glamorous/-/glamorous-3.23.4.tgz#a1e5f8045c332850105777dea4d3b21c5bdc4796"
+  dependencies:
+    brcast "^2.0.0"
+    fast-memoize "^2.2.7"
+    html-tag-names "^1.1.1"
+    react-html-attributes "^1.3.0"
+    svg-tag-names "^1.1.0"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -2937,6 +3139,13 @@ glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     minimatch "^3.0.2"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
 
 globals@^9.0.0, globals@^9.14.0:
   version "9.17.0"
@@ -3085,9 +3294,17 @@ html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
 
+html-element-attributes@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-1.3.0.tgz#f06ebdfce22de979db82020265cac541fb17d4fc"
+
 html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
+
+html-tag-names@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.2.tgz#f65168964c5a9c82675efda882875dcb2a875c22"
 
 http-errors@~1.6.1:
   version "1.6.1"
@@ -3852,6 +4069,12 @@ mimeparse@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/mimeparse/-/mimeparse-0.1.4.tgz#dafb02752370fd226093ae3152c271af01ac254a"
 
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
+
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -4263,6 +4486,10 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
 pbkdf2@^3.0.3:
   version "3.0.12"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.12.tgz#be36785c5067ea48d806ff923288c5f750b6b8a2"
@@ -4640,6 +4867,10 @@ process@^0.11.0:
   version "0.11.9"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
@@ -4880,6 +5111,18 @@ react-docgen@^2.12.1:
     node-dir "^0.1.10"
     recast "^0.11.5"
 
+react-docgen@^2.15.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.16.0.tgz#03c9eba935de8031d791ab62657b7b6606ec5da6"
+  dependencies:
+    async "^2.1.4"
+    babel-runtime "^6.9.2"
+    babylon "~5.8.3"
+    commander "^2.9.0"
+    doctrine "^2.0.0"
+    node-dir "^0.1.10"
+    recast "^0.11.5"
+
 react-dom@^15.3.2:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
@@ -4888,6 +5131,21 @@ react-dom@^15.3.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "~15.5.7"
+
+react-dom@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
+
+react-html-attributes@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-html-attributes/-/react-html-attributes-1.3.0.tgz#c97896e9cac47ad9c4e6618b835029a826f5d28c"
+  dependencies:
+    html-element-attributes "^1.0.0"
 
 react-imageloader@^2.1.0:
   version "2.1.0"
@@ -5064,6 +5322,21 @@ react-textarea-autosize@^4.3.0:
   dependencies:
     prop-types "^15.5.8"
 
+"react-typeahead@git://github.com/thomasthesecond/react-typeahead.git#refactor":
+  version "2.0.0-alpha.4"
+  resolved "git://github.com/thomasthesecond/react-typeahead.git#bea58c5d3aaa46c92e55390cae15b31249312a05"
+  dependencies:
+    "@storybook/addon-actions" "^3.1.2"
+    "@storybook/addon-knobs" "^3.1.2"
+    "@storybook/addon-links" "^3.1.2"
+    "@storybook/react" "^3.1.3"
+    chai "^4.0.2"
+    classnames "^2.2.5"
+    fuzzy "^0.1.3"
+    prop-types "^15.5.10"
+    react "^15.6.1"
+    react-dom "^15.6.1"
+
 react-validate-form@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/react-validate-form/-/react-validate-form-1.0.3.tgz#b3ae8c04b0b45e4b31f6437c481e610228bfb20e"
@@ -5078,7 +5351,17 @@ react-waypoint@^5.0.3:
   dependencies:
     consolidated-events "^1.0.1"
 
-react@>=0.13.0, react@^15.3.2, react@^15.4.2:
+react@>=0.13.0, react@^15.4.2, react@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  dependencies:
+    create-react-class "^15.6.0"
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
+
+react@^15.3.2:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
@@ -5712,6 +5995,10 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
+svg-tag-names@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/svg-tag-names/-/svg-tag-names-1.1.1.tgz#9641b29ef71025ee094c7043f7cdde7d99fbd50a"
+
 svgo@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
@@ -5859,6 +6146,14 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
+type-detect@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-3.0.0.tgz#46d0cc8553abb7b13a352b0d6dea2fd58f2d9b55"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
+
 type-is@~1.6.15:
   version "1.6.15"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz#cab10fb4909e441c82842eafe1ad646c81804410"
@@ -5957,7 +6252,11 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@^3.0.0, uuid@^3.0.1:
+uuid@^3.0.0, uuid@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 


### PR DESCRIPTION
Currently the typeahead component is in a [separate repo](https://github.com/thomasthesecond/react-typeahead/tree/refactor). This is a fork
and refactor of another popular (but poorly maintained) typeahead
component. I think my goal is to clean it up some more and publish it
properly, but for now I wanted to get it working and into Backpack.

Does anyone see any issues with this approach?

Closes #298 

![](https://cl.ly/0Z0C34372B2a/Screen%20Recording%202017-06-26%20at%2012.15%20PM.gif)

![](https://cl.ly/2P0Y0f3F0G1n/Screen%20Recording%202017-06-26%20at%2012.16%20PM.gif)