### PR TITLE
Set Checkbox input’s opacity to 0 to fix double border bug in legacy IE

### DIFF
--- a/src/components/checkbox/checkboxComponent.jsx
+++ b/src/components/checkbox/checkboxComponent.jsx
@@ -4,7 +4,6 @@ import radium from "radium";
 import kebabCase from "lodash/kebabCase";
 import { timing, zIndex } from "../../../settings.json";
 import color from "../../styles/colors";
-import { darken } from "../../utils/color";
 import font from "../../utils/font";
 import propTypes from "../../utils/propTypes";
 import Icon from "../icon";
@@ -58,7 +57,6 @@ const styles = {
     border: 0,
     left: 0,
     margin: 0,
-    outlineColor: darken(color.textSecondary, 7),
     position: "absolute",
     top: 0,
     WebkitAppearance: "none",

--- a/src/components/checkbox/checkboxComponent.jsx
+++ b/src/components/checkbox/checkboxComponent.jsx
@@ -57,6 +57,7 @@ const styles = {
     border: 0,
     left: 0,
     margin: 0,
+    opacity: 0,
     position: "absolute",
     top: 0,
     WebkitAppearance: "none",

--- a/src/components/checkbox/checkboxComponent.jsx
+++ b/src/components/checkbox/checkboxComponent.jsx
@@ -66,7 +66,6 @@ const styles = {
 
 
 class CheckboxComponent extends Component {
-
   render() {
     const {
       checked,

--- a/src/components/checkbox/checkboxComponent.jsx
+++ b/src/components/checkbox/checkboxComponent.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import radium from "radium";
 import kebabCase from "lodash/kebabCase";
 import { timing, zIndex } from "../../../settings.json";


### PR DESCRIPTION
In legacy versions of IE, the checkbox input type cannot be
styled and the appearance property is not supported. Because
of this, there was a bug in IE where the fake input’s border
and the actual input’s border both appeared.

Setting the input’s opacity to 0 fixes this bug by hiding
the element from view, but still allowing it to be
interacted with. The input can safely be hidden because the
fake input gives the visual cue as to where the checkbox is
and what it looks like.

Bug referenced in #360