### PR TITLE
Add focus state to checkbox in SettingBlockButtonWrapper

### DIFF
--- a/src/components/settingBlock/settingBlockButtonWrapper.jsx
+++ b/src/components/settingBlock/settingBlockButtonWrapper.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import radium from "radium";
+import radium, { Style } from "radium";
+import { outline } from "../../utils/mixins";
 
 const styles = {
   base: {
@@ -14,12 +15,18 @@ const styles = {
   },
 };
 
+const scopedStyles = {
+  ".SettingBlockButtonWrapper:focus .Checkbox": outline(),
+};
+
 const SettingBlockButtonWrapper = (props) => (
   <button
     className="SettingBlockButtonWrapper"
     style={[styles.base, styles.buttonResets]}
     {...props}
   >
+    <Style rules={scopedStyles} />
+
     {props.children}
   </button>
 );

--- a/src/components/settingBlock/settingBlockButtonWrapper.jsx
+++ b/src/components/settingBlock/settingBlockButtonWrapper.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import radium from "radium";
 
 const styles = {


### PR DESCRIPTION
When the button is focused, give the Checkbox component an outline. The
outline cannot be added to the Checkbox component’s input when focused
because the input is being hidden with `opacity: 0` to fix a legacy IE
bug referenced in #360