### PR TITLE
fix: remove typeahead border style

### DIFF
--- a/src/components/typeahead/styles.js
+++ b/src/components/typeahead/styles.js
@@ -99,7 +99,6 @@ const styles = {
   ".Typeahead-input": {
     backgroundColor: colors.bgPrimary,
     border: 0,
-    borderBottom: `1px solid ${colors.borderPrimary}`,
     color: "inherit",
     display: "block",
     fontFamily: "inherit",


### PR DESCRIPTION
this style was being duplicated on profile since it already exists on the settingBlockWrapper