### PR TITLE
Add primary shadow color

### DIFF
--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -18,6 +18,9 @@ const textPrimary = "#2c3643";
 const textSecondary = rgba(textPrimary, 0.7);
 const textOverlay = "#fff";
 
+// Shadow colors
+const shadowPrimary = "#000";
+
 // Accent colors
 const accentBlue = "#88bde7";
 const accentGray = "#b6c3ca";
@@ -67,6 +70,8 @@ export default {
   textPrimary,
   textSecondary,
   textOverlay,
+
+  shadowPrimary,
 
   accentBlue,
   accentGray,


### PR DESCRIPTION
We use `#000` a lot for `box-shadow`. The alpha levels vary. This color should allow us to have a default and then adjust the alpha with `rgba`.