### PR TITLE
Add alternate bookmark icons

### DIFF
--- a/src/components/bookmarkButton/index.jsx
+++ b/src/components/bookmarkButton/index.jsx
@@ -4,23 +4,32 @@ import radium from "radium";
 import ListButton from "../listButton";
 import propTypes from "../../utils/propTypes";
 
-const BookmarkButton = ({ onClick, marked, style }) => (
-  <ListButton
-    onClick={onClick}
-    icon={marked ? "BookmarkActive" : "Bookmark"}
-    style={style}
-  />
-);
+const BookmarkButton = ({ onClick, marked, iconType, style }) => {
+  const icons = {
+    default: ["BookmarkActive", "Bookmark"],
+    alternate: ["BookmarkAltActive", "BookmarkAlt"],
+  };
+
+  return (
+    <ListButton
+      onClick={onClick}
+      icon={marked ? icons[iconType][0] : icons[iconType][1]}
+      style={style}
+    />
+  );
+};
 
 BookmarkButton.propTypes = {
   onClick: PropTypes.func.isRequired,
   marked: PropTypes.bool,
+  iconType: PropTypes.oneOf(["default", "alternate"]),
   style: propTypes.style,
 };
 
 BookmarkButton.defaultProps = {
   onClick: null,
   marked: false,
+  iconType: "default",
   style: null,
 };
 

--- a/src/components/icon/index.jsx
+++ b/src/components/icon/index.jsx
@@ -130,6 +130,18 @@ exports.BookmarkActive = props => (
   </Icon>
 );
 
+exports.BookmarkAlt = props => (
+  <Icon {...props}>
+    <path d="M5.6 0v32l10.4-8.9 10.4 8.9v-32h-20.8zM23.7 26l-5.9-5-1.8-1.6-1.8 1.6-5.8 5v-23.2h15.3v23.2z" />
+  </Icon>
+);
+
+exports.BookmarkAltActive = props => (
+  <Icon {...props}>
+    <path fill={colors.accentGreen} d="M5.6 0h20.9v32l-10.5-8.9-10.4 8.9v-32z" />
+  </Icon>
+);
+
 exports.Camera = props => (
   <Icon {...props}>
     <path d="M26.3 6.3h-13.7v-0.7c0-1.5-1.2-2.7-2.7-2.7h-1.4c-1.5 0-2.7 1.2-2.7 2.7v0.7c-3.2 0-5.8 2.5-5.8 5.7v11.4c0 3.2 2.6 5.7 5.7 5.7h20.6c3.2 0 5.7-2.6 5.7-5.7v-11.4c0-3.2-2.6-5.7-5.7-5.7zM8 5.6c0-0.3 0.2-0.5 0.5-0.5h1.4c0.3 0 0.5 0.2 0.5 0.5v0.5h-2.3v-0.5zM29.7 23.4c0 1.9-1.5 3.4-3.4 3.4h-20.6c-1.9 0-3.4-1.5-3.4-3.4v-11.4c0-1.9 1.5-3.4 3.4-3.4h20.6c1.9 0 3.4 1.5 3.4 3.4v11.4z" />

--- a/src/components/listButton/index.jsx
+++ b/src/components/listButton/index.jsx
@@ -65,6 +65,8 @@ ListButton.propTypes = {
   icon: PropTypes.oneOf([
     "Bookmark",
     "BookmarkActive",
+    "BookmarkAlt",
+    "BookmarkAltActive",
     "Ellipsis",
   ]).isRequired,
   label: PropTypes.string,

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -431,6 +431,10 @@ storiesOf("Bookmark button", module)
     <Center>
       <BookmarkButton
         onClick={action("Bookmark clicked")}
+        iconType={select("Icon type", {
+          default: "Default",
+          alternate: "Alternate",
+        }, "default")}
         marked={boolean("Marked", false)}
       />
     </Center>
@@ -1080,6 +1084,8 @@ storiesOf("List Button", module)
         icon={select("Icon", [
           "Bookmark",
           "BookmarkActive",
+          "BookmarkAlt",
+          "BookmarkAltActive",
           "Ellipsis",
         ], "Ellipsis")}
       />


### PR DESCRIPTION
Desktop views use a different icon than mobile views

BoomarkButton now accepts a prop `iconType` and its value can either be "default" or "alternate".

default: 
![image](https://user-images.githubusercontent.com/1479563/29383523-57d5148a-8296-11e7-98ba-b1dff30440f5.png)

alternate: 
![image](https://user-images.githubusercontent.com/1479563/29383532-5f4688d4-8296-11e7-902c-34cbfb55ecae.png)

