### PR TITLE
Only check visibility in ListItemBookmark

### DIFF
--- a/src/components/listItemBookmark/index.jsx
+++ b/src/components/listItemBookmark/index.jsx
@@ -127,7 +127,7 @@ function ListItemBookmark({
           {name}
         </Heading>
 
-        {visibility && entriesCount &&
+        {visibility &&
           <CategoryLabel style={styles.meta}>
             {visibility} · {entriesCount} place{entriesCount !== 1 && "s"}
           </CategoryLabel>


### PR DESCRIPTION
`{visibility && entriesCount &&` was added to hide the meta data if the component was used for the "add new list" button. However, if `entriesCount` was 0, then the condition returned false and output a 0 to the screen.

I think it should be enough to check for `visibility` only because if the component is used for "add new list" button, it shouldn't have `visibility`. Also, we want to show "0 places" on the item if there are none, so it's ok if `entriesCount` is 0.