### PR TITLE
Allow setInnerHTML on ArticlePreview paragraph

### DIFF
--- a/src/components/articlePreview/index.jsx
+++ b/src/components/articlePreview/index.jsx
@@ -6,6 +6,8 @@ import font from "../../utils/font";
 import CategoryLabelLink from "../categoryLabelLink";
 import Heading from "../heading";
 
+const markup = html => ({ __html: html });
+
 function ArticlePreview({ title, paragraph, image, href, category, categoryHref }) {
   const styles = {
     container: {
@@ -66,9 +68,10 @@ function ArticlePreview({ title, paragraph, image, href, category, categoryHref 
             {title}
           </Heading>
 
-          <p style={styles.paragraph}>
-            {paragraph}
-          </p>
+          <p
+            style={styles.paragraph}
+            dangerouslySetInnerHTML={markup(paragraph)}
+          />
         </a>
       </div>
     </article>

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -371,7 +371,7 @@ storiesOf("Article preview", module)
   .add("Default", () => (
     <ArticlePreview
       title={text("Title", "New York’s most iconic buildings reimagined on deserted streets")}
-      paragraph={text("Paragraph", "A new exhibition in New York of the city’s most iconic buildings shows them in a new light, with the bustle of modern life stripped out. Photographer")}
+      paragraph={text("Paragraph", "A new exhibition in New York of the city’s most &ldquo;iconic&rdquo; buildings shows them in a new light, with the bustle of modern life stripped out. Photographer")}
       image={text("Image URL", "http://placehold.it/410x230")}
       href={text("URL", "/")}
       category={text("Category name", "Art and culture")}


### PR DESCRIPTION
Sometimes the content from the Wordpress API comes back with encoded
characters.