### PR TITLE
Create new text input components

### DIFF
--- a/src/components/input/index.jsx
+++ b/src/components/input/index.jsx
@@ -21,7 +21,11 @@ const styles = {
   fontSize: `${fontSizeHeading7}px`,
   fontWeight: fontWeightMedium,
   lineHeight: lineHeightHeading7,
-  padding: "4px 0 0",
+  minHeight: `${height}px`,
+  padding: `
+    ${17 / fontSizeHeading7}em
+    0
+    ${15 / fontSizeHeading7}em`,
   transition: `
     backgroundColor ${timing.fast},
     border-bottom-color ${timing.fast},

--- a/src/components/input/index.jsx
+++ b/src/components/input/index.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import radium from "radium";
+import colors from "../../styles/colors";
+import timing from "../../styles/timing";
+import {
+  fontSizeHeading7,
+  fontWeightMedium,
+  lineHeightHeading7,
+} from "../../styles/typography";
+import propTypes from "../../utils/propTypes";
+
+const height = 56;
+
+const styles = {
+  backgroundColor: colors.bgPrimary,
+  display: "block",
+  borderBottomColor: colors.borderPrimary,
+  borderBottomStyle: "solid",
+  borderWidth: "0 0 1px 0",
+  height: `${(height / fontSizeHeading7)}em`,
+  fontSize: `${fontSizeHeading7}px`,
+  fontWeight: fontWeightMedium,
+  lineHeight: lineHeightHeading7,
+  padding: "4px 0 0",
+  transition: `
+    backgroundColor ${timing.fast},
+    border-bottom-color ${timing.fast},
+    color ${timing.fast}`,
+  width: "100%",
+
+  ":focus": {
+    borderBottomColor: colors.linkPrimary,
+    outline: "none",
+  },
+};
+
+const Input = (props) => (
+  <input
+    {...props}
+    style={[styles, props.style]}
+  />
+);
+
+Input.propTypes = {
+  style: propTypes.style,
+};
+
+Input.defaultProps = {
+  type: "text",
+  style: null,
+};
+
+Input.styles = styles;
+Input.fontSize = fontSizeHeading7;
+Input.lineHeight = (lineHeightHeading7 * fontSizeHeading7);
+Input.height = height;
+
+export default radium(Input);

--- a/src/components/textarea/index.jsx
+++ b/src/components/textarea/index.jsx
@@ -5,9 +5,6 @@ import propTypes from "../../utils/propTypes";
 import Input from "../input";
 
 const styles = Object.assign({}, Input.styles, {
-  height: "auto",
-  minHeight: Input.styles.height,
-  padding: 0,
   resize: "vertical",
 });
 
@@ -60,10 +57,11 @@ class Textarea extends React.Component {
         onInput={this.onInput}
         style={[
           styles,
+          !this.props.autogrow && {
+            height: "auto",
+          },
           this.props.autogrow && {
-            height: Input.styles.height,
             overflow: "hidden",
-            padding: `${17 / Input.fontSize}em 0 ${15 / Input.fontSize}em`,
             resize: "none",
           },
           this.props.style,

--- a/src/components/textarea/index.jsx
+++ b/src/components/textarea/index.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+import PropTypes from "prop-types";
+import radium from "radium";
+import propTypes from "../../utils/propTypes";
+import Input from "../input";
+
+const styles = Object.assign({}, Input.styles, {
+  height: "auto",
+  minHeight: Input.styles.height,
+  padding: 0,
+  resize: "vertical",
+});
+
+class Textarea extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      height: Input.height,
+      hideOverflow: true,
+    };
+
+    this.onInput = this.onInput.bind(this);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) { // eslint-disable-line class-methods-use-this
+    return nextState.height !== nextState.maxHeight;
+  }
+
+  onInput() {
+    if (this.props.onInput && typeof this.props.onInput === "function") {
+      this.props.onInput();
+    }
+
+    if (this.props.autogrow) {
+      const maxHeight = (this.props.maxLines * Input.lineHeight) + Input.height;
+
+      this.textarea.style.height = Input.styles.height;
+
+      this.setState({
+        height: Math.min(this.textarea.scrollHeight, maxHeight),
+        hideOverflow: Math.min(this.textarea.scrollHeight, maxHeight) < maxHeight,
+      }, () => {
+        this.textarea.style.height = `${this.state.height}px`;
+        this.textarea.style.overflow = this.state.hideOverflow ? "hidden" : null;
+      });
+    }
+  }
+
+  render() {
+    const props = Object.assign({}, this.props);
+
+    delete props.autogrow;
+    delete props.maxLines;
+
+    return (
+      <textarea
+        {...props}
+        ref={node => { this.textarea = node; }}
+        onInput={this.onInput}
+        style={[
+          styles,
+          this.props.autogrow && {
+            height: Input.styles.height,
+            overflow: "hidden",
+            padding: `${17 / Input.fontSize}em 0 ${15 / Input.fontSize}em`,
+            resize: "none",
+          },
+          this.props.style,
+        ]}
+      />
+    );
+  }
+}
+
+Textarea.propTypes = {
+  autogrow: PropTypes.bool,
+  maxLines: PropTypes.number,
+  onInput: PropTypes.func,
+  style: propTypes.style,
+};
+
+Textarea.defaultProps = {
+  autogrow: false,
+  maxLines: 3,
+  onInput: null,
+  style: null,
+};
+
+export default radium(Textarea);

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -76,7 +76,8 @@ import IconCalloutGroup from "../src/components/iconCalloutGroup";
 import ImageCarousel from "../src/components/imageCarousel";
 // ImageGallery
 import ImageHero from "../src/components/imageHero";
-import Input from "../src/components/form/input";
+import Input from "../src/components/input";
+import FormInput from "../src/components/form/input";
 import InteractiveMap from "../src/components/interactiveMap";
 import ItalicText from "../src/components/italicText";
 // LastUpdated
@@ -138,7 +139,7 @@ import SettingBlockAction from "../src/components/settingBlockAction";
 import SettingBlockAccordion from "../src/components/settingBlockAccordion";
 import SettingBlockTextArea from "../src/components/settingBlockTextArea";
 import SettingBlockInput from "../src/components/settingBlockInput";
-import TextArea from "../src/components/form/textarea";
+import FormTextArea from "../src/components/form/textarea";
 import ToggleController from "../src/utils/toggleController";
 import ShareMenu from "../src/components/shareMenu";
 import Slide from "../src/components/slide";
@@ -162,6 +163,7 @@ import TagList from "../src/components/tagList";
 import TallCarousel from "../src/components/tallCarousel";
 import { TextAccent, TextBodyArticle, TextBodySmall, TextHeading, TextSuper, TextUppercase } from "../src/components/text";
 import TextBubble from "../src/components/textBubble";
+import Textarea from "../src/components/textarea";
 import ThumbnailListItem from "../src/components/thumbnailListItem";
 import TileGrid from "../src/components/tileGrid";
 import TileVideo from "../src/components/tileVideo";
@@ -768,21 +770,21 @@ storiesOf("Expand button", module)
     <ExpandButton label={text("Label", "Open")} />
   ));
 
-
 storiesOf("Form", module)
   .addDecorator(withKnobs)
   .add("Input", () => (
-    <Input
+    <FormInput
       placeholder={text("Placeholder", "johndoe@gmail.com")}
       error={boolean("Has Error", false)}
       theme={select("Input Theme", ["base", "light", "dark", "float", "inputGroup"], "base")}
     />
   ))
-  .add("Text Area", () => (
-    <TextArea
+  .add("Textarea", () => (
+    <FormTextArea
       placeholder={text("Placeholder", "johndoe@gmail.com")}
       error={boolean("Has Error", false)}
       theme={select("Input Theme", ["base", "light", "dark", "float", "inputGroup"], "base")}
+      autogrow={boolean("Autogrow", false)}
     />
   ))
   .add("ErrorMessages", () => (
@@ -1054,6 +1056,14 @@ storiesOf("Image hero", module)
       image={text("Image URL", "https://s3.amazonaws.com/static-asset/backpack-ui/ImageHero.770x430.jpg")}
       imageSize={array("Size", [770, 430])}
     />
+  ));
+
+storiesOf("Input", module)
+  .addDecorator(withKnobs)
+  .add("Default", () => (
+    <Center backgroundColor="white">
+      <Input />
+    </Center>
   ));
 
 storiesOf("Interactive Map", module)
@@ -2527,6 +2537,22 @@ storiesOf("Text bubble", module)
   .addDecorator(withKnobs)
   .add("Default", () => (
     <TextBubble>{text("Text", "44 mins")}</TextBubble>
+  ));
+
+storiesOf("Textarea", module)
+  .addDecorator(withKnobs)
+  .add("Default", () => (
+    <Center backgroundColor="white">
+      <Textarea />
+    </Center>
+  ))
+  .add("Autogrow", () => (
+    <Center backgroundColor="white">
+      <Textarea
+        maxLines={number("Maximum lines", 3)}
+        autogrow
+      />
+    </Center>
   ));
 
 storiesOf("Thumbnail list item", module)


### PR DESCRIPTION
* Deprecates `form/input.jsx` and `form/textarea.jsx`
* Accepts any valid attributes for `input` or `textarea` elements
* Textarea component can autogrow; use props `autogrow` and `maxLines`
* No more themes; pass in styles from design tokens to change height, font size, padding, etc.