### PR TITLE
fix: disable scroll lock off after navigate

### DIFF
--- a/src/components/modal/wrapper.jsx
+++ b/src/components/modal/wrapper.jsx
@@ -11,6 +11,15 @@ class ModalWrapper extends React.Component {
     };
 
     this.toggleOpen = this.toggleOpen.bind(this);
+    this.handleNavigateAway = this.handleNavigateAway.bind(this);
+  }
+
+  componentDidMount() {
+    window.onbeforeunload = this.handleNavigateAway;
+  }
+
+  componentWillUnmount() {
+    this.handleNavigateAway();
   }
 
   toggleOpen() {
@@ -23,6 +32,11 @@ class ModalWrapper extends React.Component {
         noScroll.off();
       }
     });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  handleNavigateAway() {
+    noScroll.off();
   }
 
   render() {


### PR DESCRIPTION
currently if a user navigates away from a page while a modal is open, the scroll lock on the html stays in place so you can't scroll

this fixes the issue by listening to navigation and unMount events to remove the fixed window styles 