### PR TITLE
fix: refactor bookmarkButtonAlt to use a lower level component

### DIFF
--- a/src/components/bookmarkButtonAlt/index.jsx
+++ b/src/components/bookmarkButtonAlt/index.jsx
@@ -1,103 +1,21 @@
 import React from "react";
 import PropTypes from "prop-types";
-import radium, { Style } from "radium";
+import radium from "radium";
 import cn from "classnames";
 import { BookmarkAltActive, BookmarkAlt } from "../icon";
-import colors from "../../styles/colors";
-import timing from "../../styles/timing";
-import { fontSizeUppercase, lineHeightReset } from "../../styles/typography";
-import { outline } from "../../utils/mixins";
 import propTypes from "../../utils/propTypes";
+import IconRevealButton from "../iconRevealButton";
 
-const styles = {
-  container: {
-    alignItems: "center",
-    backgroundColor: "transparent",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    lineHeight: lineHeightReset,
-    textAlign: "center",
-
-    ":focus": outline(4),
-  },
-
-  icon: {
-    transition: `transform ${timing.fast} ease-in-out`,
-  },
-
-  iconInactive: {
-    transition: `color ${timing.fast} ease-in-out,
-      transform ${timing.fast} ease-in-out`,
-  },
-
-  label: {
-    fontSize: `${fontSizeUppercase}px`,
-    opacity: 0,
-    transition: `opacity ${timing.fast} ease-in-out,
-      visibility ${timing.fast} ease-in-out`,
-    visibility: "hidden",
-  },
-};
 
 const BookmarkButtonAlt = ({ onClick, marked, id, className, style }) => (
-  <button
+  <IconRevealButton
     id={id}
     className={cn("BookmarkButtonAlt", className)}
     onClick={onClick}
-    style={[styles.container, style]}
-  >
-    <Style
-      rules={{
-        ".BookmarkButtonAlt:hover > svg": {
-          transform: "translateY(-4px) !important",
-        },
-        ".BookmarkButtonAlt:active > svg": {
-          transform: "translateY(-4px) !important",
-        },
-        ".BookmarkButtonAlt:focus > svg": {
-          transform: "translateY(-4px) !important",
-        },
-
-        ".BookmarkButtonAlt:hover > svg.inactive": {
-          color: `${colors.accentGray} !important`,
-        },
-        ".BookmarkButtonAlt:active > svg.inactive": {
-          color: `${colors.accentGray} !important`,
-        },
-        ".BookmarkButtonAlt:focus > svg.inactive": {
-          color: `${colors.accentGray} !important`,
-        },
-
-        ".BookmarkButtonAlt:hover > span": {
-          opacity: "1 !important",
-          visibility: "visible !important",
-        },
-        ".BookmarkButtonAlt:active > span": {
-          opacity: "1 !important",
-          visibility: "visible !important",
-        },
-        ".BookmarkButtonAlt:focus > span": {
-          opacity: "1 !important",
-          visibility: "visible !important",
-        },
-      }}
-    />
-
-    {marked ?
-      <BookmarkAltActive
-        style={styles.icon}
-      /> :
-      <BookmarkAlt
-        className="inactive"
-        style={styles.iconInactive}
-      />
-    }
-
-    <span style={styles.label}>
-      Save
-    </span>
-  </button>
+    icon={marked ? <BookmarkAltActive /> : <BookmarkAlt />}
+    style={style}
+    label="Save"
+  />
 );
 
 BookmarkButtonAlt.propTypes = {

--- a/src/components/iconRevealButton/index.jsx
+++ b/src/components/iconRevealButton/index.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+import PropTypes from "prop-types";
+import radium, { Style } from "radium";
+import cn from "classnames";
+import { BookmarkAlt } from "../icon";
+import colors from "../../styles/colors";
+import timing from "../../styles/timing";
+import { fontSizeUppercase, lineHeightReset } from "../../styles/typography";
+import { outline } from "../../utils/mixins";
+import propTypes from "../../utils/propTypes";
+
+const styles = {
+  container: {
+    alignItems: "center",
+    backgroundColor: "transparent",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    lineHeight: lineHeightReset,
+    textAlign: "center",
+
+    ":focus": outline(4),
+  },
+
+  icon: {
+    transition: `color ${timing.fast} ease-in-out, transform ${timing.fast} ease-in-out`,
+  },
+
+  label: {
+    fontSize: `${fontSizeUppercase}px`,
+    opacity: 0,
+    transition: `opacity ${timing.fast} ease-in-out,
+      visibility ${timing.fast} ease-in-out`,
+    visibility: "hidden",
+  },
+};
+
+const IconRevealButton = ({
+  onClick,
+  icon,
+  label,
+  id,
+  className,
+  style,
+}) => (
+  <button
+    id={id}
+    className={cn("IconRevealButton", className)}
+    onClick={onClick}
+    style={[styles.container, style]}
+  >
+    <Style
+      rules={{
+        ".IconRevealButton:hover > svg": {
+          transform: "translateY(-4px) !important",
+          color: `${colors.accentGray} !important`,
+        },
+        ".IconRevealButton:active > svg": {
+          transform: "translateY(-4px) !important",
+          color: `${colors.accentGray} !important`,
+        },
+        ".IconRevealButton:focus > svg": {
+          transform: "translateY(-4px) !important",
+          color: `${colors.accentGray} !important`,
+        },
+
+        ".IconRevealButton:hover > span": {
+          opacity: "1 !important",
+          visibility: "visible !important",
+        },
+        ".IconRevealButton:active > span": {
+          opacity: "1 !important",
+          visibility: "visible !important",
+        },
+        ".IconRevealButton:focus > span": {
+          opacity: "1 !important",
+          visibility: "visible !important",
+        },
+      }}
+    />
+
+    {React.cloneElement(icon, {
+      style: {
+        ...styles.icon,
+        ...icon.style,
+      },
+    })}
+    {label &&
+      <span style={styles.label}>
+        {label}
+      </span>
+    }
+  </button>
+);
+
+IconRevealButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  icon: PropTypes.element.isRequired,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  className: PropTypes.string,
+  style: propTypes.style,
+};
+
+IconRevealButton.defaultProps = {
+  onClick: null,
+  icon: <BookmarkAlt />,
+  id: null,
+  className: null,
+  style: null,
+};
+
+export default radium(IconRevealButton);

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -78,6 +78,7 @@ import ImageCarousel from "../src/components/imageCarousel";
 import ImageHero from "../src/components/imageHero";
 import Input from "../src/components/input";
 import FormInput from "../src/components/form/input";
+import IconRevealButton from "../src/components/iconRevealButton";
 import InteractiveMap from "../src/components/interactiveMap";
 import ItalicText from "../src/components/italicText";
 // LastUpdated
@@ -1035,6 +1036,22 @@ storiesOf("Icon callout group", module)
           copy="Keep safe and well on the open road"
         />
       </IconCalloutGroup>
+    </StyleRoot>
+  ));
+
+storiesOf("Icon Reveal Button", module)
+  .addDecorator(withKnobs)
+  .add("Default", () => (
+    <StyleRoot>
+      <Center>
+        <IconRevealButton
+          id={text("ID", null)}
+          icon={<Icon.Share />}
+          label={text("Label", "Label")}
+          className={text("Classname", null)}
+          onClick={action("Bookmark clicked")}
+        />
+      </Center>
     </StyleRoot>
   ));
 


### PR DESCRIPTION
need to build a component like the bookmarkButtonAlt that can take any icon in (ie Share).

Built a lower level IconRevealButton that will take any icon and any string to work the same way as the bookmarkButtonAlt currently works, then rebuilt the bookmarkButtonAlt component using the new IconRevealButton;
![screen capture on 2017-09-29 at 14-30-11](https://user-images.githubusercontent.com/4378776/31032708-c0a2a190-a522-11e7-8c8b-11618153725c.gif)
