### PR TITLE
Set node type for text components children

### DIFF
--- a/src/components/text/textAccent.jsx
+++ b/src/components/text/textAccent.jsx
@@ -18,7 +18,7 @@ const TextAccent = (props) => (
 );
 
 TextAccent.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   style: propTypes.style,
 };
 

--- a/src/components/text/textBodyArticle.jsx
+++ b/src/components/text/textBodyArticle.jsx
@@ -18,7 +18,7 @@ const TextBodyArticle = (props) => (
 );
 
 TextBodyArticle.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   style: propTypes.style,
 };
 

--- a/src/components/text/textBodyArticleSmall.jsx
+++ b/src/components/text/textBodyArticleSmall.jsx
@@ -18,7 +18,7 @@ const TextBodyArticleSmall = (props) => (
 );
 
 TextBodyArticleSmall.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   style: propTypes.style,
 };
 

--- a/src/components/text/textBodySmall.jsx
+++ b/src/components/text/textBodySmall.jsx
@@ -18,7 +18,7 @@ const TextBodySmall = (props) => (
 );
 
 TextBodySmall.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   style: propTypes.style,
 };
 

--- a/src/components/text/textUppercase.jsx
+++ b/src/components/text/textUppercase.jsx
@@ -18,7 +18,7 @@ const TextUppercase = (props) => (
 );
 
 TextUppercase.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   style: propTypes.style,
 };
 


### PR DESCRIPTION
change: Set "node" prop type for text components

Makes f.e. anchor child valid. Heading components already accept nodes.