### PR TITLE
Fix bugs in ProfileHeader

### DIFF
--- a/src/components/profileHeader/index.jsx
+++ b/src/components/profileHeader/index.jsx
@@ -335,7 +335,7 @@ class ProfileHeader extends React.Component {
 ProfileHeader.propTypes = {
   name: PropTypes.string.isRequired,
   intro: PropTypes.string,
-  website: PropTypes.website,
+  website: PropTypes.string,
   avatarSrc: PropTypes.string,
   location: PropTypes.string,
   interests: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/profileHeader/index.jsx
+++ b/src/components/profileHeader/index.jsx
@@ -38,17 +38,21 @@ class ProfileHeader extends React.Component {
   }
 
   componentDidMount() {
-    window.addEventListener("resize", () => {
-      setTimeout(() => {
-        this.toggleReadMoreLink();
-      }, 100);
-    });
+    if (this.props.intro) {
+      window.addEventListener("resize", () => {
+        setTimeout(() => {
+          this.toggleReadMoreLink();
+        }, 100);
+      });
 
-    this.toggleReadMoreLink();
+      this.toggleReadMoreLink();
+    }
   }
 
   componentWillUnmount() {
-    window.removeEventListener("resize", this.toggleReadMoreLink);
+    if (this.props.intro) {
+      window.removeEventListener("resize", this.toggleReadMoreLink);
+    }
   }
 
   toggleReadMoreLink() {

--- a/src/components/profileHeader/index.jsx
+++ b/src/components/profileHeader/index.jsx
@@ -271,7 +271,11 @@ class ProfileHeader extends React.Component {
                 ]}
               >
                 <a href={website} target="_blank" rel="noopener noreferrer">
-                  {website.substr(website.indexOf("://") + 3).replace("www.", "")}
+                  {website
+                    .replace("https://", "")
+                    .replace("http://", "")
+                    .replace("www.", "")
+                  }
                 </a>
               </p>
             }

--- a/src/components/profileHeader/index.jsx
+++ b/src/components/profileHeader/index.jsx
@@ -345,7 +345,13 @@ ProfileHeader.propTypes = {
 };
 
 ProfileHeader.defaultProps = {
+  intro: "",
+  website: "",
+  avatarSrc: "",
+  location: "",
+  interests: [],
   alignment: "center",
+  style: null,
 };
 
 export default radium(ProfileHeader);


### PR DESCRIPTION
There is still an issue with the toggleReadMoreLink method. I wasn't able to get the correct lifecycle method working, so if you have no bio and then update your bio, and it's long enough that it needs the "read more" link, the link won't show up until a page refresh. This is because I'm not running `componentWillReceiveProps`. It's something I will keep looking into, but I wanted to get this fix up as it's broken on production.