### PR TITLE
Make sure profile header URL has `http://` in href

### DIFF
--- a/src/components/profileHeader/index.jsx
+++ b/src/components/profileHeader/index.jsx
@@ -225,11 +225,15 @@ class ProfileHeader extends React.Component {
       }
     `;
 
-    const formattedWebsite = website ? website
-      .replace("https://", "")
-      .replace("http://", "")
-      .replace("www.", "")
-    : "";
+    const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/; // eslint-disable-line max-len
+
+    const validateUrl = (url) => urlRegex.test(url);
+
+    const urlParser = (url) => {
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      return anchor;
+    };
 
     return (
       <header
@@ -272,7 +276,7 @@ class ProfileHeader extends React.Component {
               </Heading>
             }
 
-            {website &&
+            {website && validateUrl(website) &&
               <p
                 style={[
                   styles.textBodySmall,
@@ -281,11 +285,11 @@ class ProfileHeader extends React.Component {
                 ]}
               >
                 <a
-                  href={`http://${formattedWebsite}`}
+                  href={website}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {formattedWebsite}
+                  {urlParser(website).hostname.replace("www.", "")}
                 </a>
               </p>
             }

--- a/src/components/profileHeader/index.jsx
+++ b/src/components/profileHeader/index.jsx
@@ -225,6 +225,12 @@ class ProfileHeader extends React.Component {
       }
     `;
 
+    const formattedWebsite = website ? website
+      .replace("https://", "")
+      .replace("http://", "")
+      .replace("www.", "")
+    : "";
+
     return (
       <header
         className="ProfileHeader"
@@ -274,12 +280,12 @@ class ProfileHeader extends React.Component {
                   styles.website[alignment],
                 ]}
               >
-                <a href={website} target="_blank" rel="noopener noreferrer">
-                  {website
-                    .replace("https://", "")
-                    .replace("http://", "")
-                    .replace("www.", "")
-                  }
+                <a
+                  href={`http://${formattedWebsite}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {formattedWebsite}
                 </a>
               </p>
             }


### PR DESCRIPTION
We don't want to show `http://` in the UI, but the href needs
it. The bug was caused by the assumption that `http://` would
always be there. The fix is just to remove `http://` and
then add it back in the href so it will always be there.