### PR TITLE
fix: only allow photos to be uploaded via avatart uploader

### DIFF
--- a/src/components/avatarUpload/index.jsx
+++ b/src/components/avatarUpload/index.jsx
@@ -158,6 +158,7 @@ class AvatarUpload extends Component {
           <input
             id="avatarUploadInput"
             type="file"
+            accept="image/*"
             ref={node => (this.input = node)}
             onChange={this.onChange}
             style={styles.input}


### PR DESCRIPTION
currently on mobile the native menu for adding a photo to the avatar upload allows you to also add video. this crashes the site/app. 

this pr limits file types to just images

fixes https://github.com/lonelyplanet/dotcom-profile/issues/401