### PR TITLE
fix: return empty hostname from urlparser if server rendr

### DIFF
--- a/src/components/profileHeader/index.jsx
+++ b/src/components/profileHeader/index.jsx
@@ -231,7 +231,7 @@ class ProfileHeader extends React.Component {
 
     const urlParser = (url) => {
       if (typeof document === "undefined") {
-        return false;
+        return { hostname: "" };
       }
 
       const anchor = typeof document !== "undefined" ? document.createElement("a") : null;


### PR DESCRIPTION
urlParser was still trying to perform a `replace` function on the return value so I am returning an empty string instead of false for now