### PR TITLE
Update ProfileHeader layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,7 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -139,6 +140,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -6658,6 +6660,7 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -6666,6 +6669,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -8340,11 +8344,13 @@
       }
     },
     "react-measure": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-0.4.2.tgz",
-      "integrity": "sha1-PPqP9zFOoPtfuPE3seT8bIFwHZs=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.0.2.tgz",
+      "integrity": "sha1-ByqaX6/AHfutwfpfsJ/DUQN/Y2w=",
       "requires": {
-        "element-resize-detector": "1.1.12"
+        "get-node-dimensions": "1.2.0",
+        "prop-types": "15.5.10",
+        "resize-observer-polyfill": "1.4.2"
       }
     },
     "react-modal": {
@@ -8394,6 +8400,16 @@
         "get-prefix": "1.0.0",
         "react-measure": "0.4.2",
         "react-motion": "0.4.8"
+      },
+      "dependencies": {
+        "react-measure": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-0.4.2.tgz",
+          "integrity": "sha1-PPqP9zFOoPtfuPE3seT8bIFwHZs=",
+          "requires": {
+            "element-resize-detector": "1.1.12"
+          }
+        }
       }
     },
     "react-onclickoutside": {
@@ -8946,6 +8962,11 @@
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
       }
+    },
+    "resize-observer-polyfill": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.4.2.tgz",
+      "integrity": "sha1-o3GY5iCeiIrLFTKplo4G04tniOU="
     },
     "resolve": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-dom": "^15.3.2",
     "react-imageloader": "^2.1.0",
     "react-markdown-renderer": "^1.4.0",
+    "react-measure": "^2.0.2",
     "react-modal": "^1.6.5",
     "react-motion": "^0.4.4",
     "react-motion-ui-pack": "^0.9.0",
@@ -77,11 +78,11 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
-    "@types/react": "^16.0.5",
     "@storybook/addon-actions": "^3.1.9",
     "@storybook/addon-knobs": "^3.0.0",
     "@storybook/addon-links": "^3.0.0",
     "@storybook/react": "^3.0.1",
+    "@types/react": "^16.0.5",
     "babel-cli": "^6.14.0",
     "babel-eslint": "^6.1.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",

--- a/src/components/profileHeader/index.jsx
+++ b/src/components/profileHeader/index.jsx
@@ -1,14 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import radium from "radium";
-import MarkdownRenderer from "react-markdown-renderer";
-import cn from "classnames";
 import Avatar from "../avatar";
 import LocationLabel from "../locationLabel";
 import Tag from "../tag";
 import TagList from "../tagList";
-import MoreLink from "../moreLink";
 import { Heading } from "../text";
+import ProfileIntro from "../profileIntro";
 import colors from "../../styles/colors";
 import {
   fontSizeHeading7,
@@ -17,7 +15,6 @@ import {
   lineHeightReset,
 } from "../../styles/typography";
 import { textBodySmall } from "../../utils/typography";
-import { rgba } from "../../utils/color";
 import propTypes from "../../utils/propTypes";
 
 class ProfileHeader extends React.Component {
@@ -25,52 +22,9 @@ class ProfileHeader extends React.Component {
     super(props);
 
     this.state = {
-      expanded: false,
-      showReadMore: false,
     };
 
-    this.maxLines = 3;
     this.paragraphLineHeight = 24;
-    this.maxHeight = (this.paragraphLineHeight * this.maxLines);
-
-    this.toggleReadMoreLink = this.toggleReadMoreLink.bind(this);
-    this.toggleExpandedState = this.toggleExpandedState.bind(this);
-  }
-
-  componentDidMount() {
-    if (this.props.intro) {
-      window.addEventListener("resize", () => {
-        setTimeout(() => {
-          this.toggleReadMoreLink();
-        }, 100);
-      });
-
-      this.toggleReadMoreLink();
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.props.intro) {
-      window.removeEventListener("resize", this.toggleReadMoreLink);
-    }
-  }
-
-  toggleReadMoreLink() {
-    // MarkdownRenderer wraps `props.intro` with `p` element, which is
-    // needed to calculate the height of the text. If you remove
-    // MarkdownRenderer, make sure to wrap `props.intro` with a `p`
-    // element.
-    const height = this.clampedText.querySelector("p").offsetHeight;
-
-    this.setState({
-      showReadMore: (height / this.paragraphLineHeight) > this.maxLines,
-    });
-  }
-
-  toggleExpandedState() {
-    this.setState({
-      expanded: !this.state.expanded,
-    });
   }
 
   render() {
@@ -149,7 +103,7 @@ class ProfileHeader extends React.Component {
         },
       },
 
-      bio: {
+      intro: {
         default: {
           marginTop: "37px",
         },
@@ -181,50 +135,6 @@ class ProfileHeader extends React.Component {
       }, textBodySmall()),
     };
 
-    const lineHeight = (alignment === "center" && (this.paragraphLineHeight / fontSizeBodySmall)) ||
-      (alignment === "left" && lineHeightHeading7);
-
-    const markup = (htmlContent) => ({ __html: htmlContent });
-
-    const dangerousStyles = `
-      .ProfileHeader .ClampedText img,
-      .ProfileHeader .ClampedText video,
-      .ProfileHeader .ClampedText iframe {
-        display: none !important;
-      }
-
-      .ProfileHeader .ClampedText:not(.expanded) {
-        display: block;
-        display: -webkit-box;
-        height: calc(1em * ${lineHeight} * ${this.maxLines});
-        line-height: ${lineHeight};
-        overflow: hidden;
-        padding: 0;
-        position: relative;
-        text-overflow: ellipsis;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: ${this.maxLines};
-      }
-
-      .ProfileHeader .ClampedText:not(.expanded)::after {
-        background: linear-gradient(to right, ${rgba(colors.bgPrimary, 0)}, ${rgba(colors.bgPrimary, 1)} 75%);
-        bottom: 0;
-        content: "…";
-        display: block;
-        height: calc(1em * ${lineHeight});
-        position: absolute;
-        right: 0;
-        text-align: right;
-        width: 10%;
-      }
-
-      @supports (-webkit-line-clamp: ${this.maxLines}) {
-        .ProfileHeader .ClampedText:not(.expanded)::after {
-          display: none !important;
-        }
-      }
-    `;
-
     const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/; // eslint-disable-line max-len
 
     const validateUrl = (url) => urlRegex.test(url);
@@ -247,10 +157,6 @@ class ProfileHeader extends React.Component {
           style,
         ]}
       >
-        <style
-          dangerouslySetInnerHTML={markup(dangerousStyles)}
-        />
-
         <div style={styles.flexContainer[alignment]}>
           {avatarSrc &&
             <Avatar
@@ -301,37 +207,21 @@ class ProfileHeader extends React.Component {
         </div>
 
         {intro &&
-          <div
+          <ProfileIntro
+            maxLines={3}
+            fontSize={
+              (alignment === "center" && fontSizeBodySmall) ||
+              (alignment === "left" && fontSizeHeading7)
+            }
+            lineHeight={this.paragraphLineHeight}
             style={[
               styles.textBodySmall,
-              styles.bio.default,
-              styles.bio[alignment],
+              styles.intro.default,
+              styles.intro[alignment],
             ]}
           >
-            <div
-              className={cn("ClampedText", this.state.expanded && "expanded")}
-              ref={node => { this.clampedText = node; }}
-            >
-              {/*
-                Wrap {intro} with `p` and delete this comment
-                **if** MarkdownRenderer is removed
-              */}
-              <MarkdownRenderer
-                markdown={intro}
-              />
-            </div>
-
-            {this.state.showReadMore &&
-              <MoreLink
-                caps
-                size="small"
-                hideIcon
-                onClick={this.toggleExpandedState}
-              >
-                {this.state.expanded ? "Read less" : "Read more"}
-              </MoreLink>
-            }
-          </div>
+            {intro}
+          </ProfileIntro>
         }
 
         {interests && interests.length > 0 &&

--- a/src/components/profileHeader/index.jsx
+++ b/src/components/profileHeader/index.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import radium from "radium";
+import Measure from "react-measure";
 import Avatar from "../avatar";
 import LocationLabel from "../locationLabel";
 import Tag from "../tag";
@@ -22,6 +23,9 @@ class ProfileHeader extends React.Component {
     super(props);
 
     this.state = {
+      dimensions: {
+        width: -1,
+      },
     };
 
     this.paragraphLineHeight = 24;
@@ -36,9 +40,13 @@ class ProfileHeader extends React.Component {
       location,
       interests,
       interestsLimit,
-      alignment,
       style,
     } = this.props;
+
+    const { width } = this.state.dimensions;
+
+    // Change the layout based on the component's size
+    const alignment = (width > 540) ? "left" : "center";
 
     const styles = {
       header: {
@@ -150,92 +158,104 @@ class ProfileHeader extends React.Component {
     };
 
     return (
-      <header
-        className="ProfileHeader"
-        style={[
-          styles.header[alignment],
-          style,
-        ]}
+      <Measure
+        bounds
+        onResize={(contentRect) => {
+          this.setState({
+            dimensions: contentRect.bounds,
+          });
+        }}
       >
-        <div style={styles.flexContainer[alignment]}>
-          {avatarSrc &&
-            <Avatar
-              src={avatarSrc}
-              alt={`Avatar for user ${name}`}
-              size={80}
-              className="ProfileHeader-avatar"
-              style={styles.avatar[alignment]}
-            />
-          }
-
-          <div style={styles.textContainer[alignment]}>
-            {location &&
-              <LocationLabel style={styles.locationLabel[alignment]}>
-                {location}
-              </LocationLabel>
-            }
-
-            {name &&
-              <Heading
-                level={1}
-                size={5}
-                weight="medium"
-                style={styles.heading}
-              >
-                {name}
-              </Heading>
-            }
-
-            {website && validateUrl(website) &&
-              <p
-                style={[
-                  styles.textBodySmall,
-                  styles.website.default,
-                  styles.website[alignment],
-                ]}
-              >
-                <a
-                  href={website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {urlParser(website).hostname.replace("www.", "")}
-                </a>
-              </p>
-            }
-          </div>
-        </div>
-
-        {intro &&
-          <ProfileIntro
-            maxLines={3}
-            fontSize={
-              (alignment === "center" && fontSizeBodySmall) ||
-              (alignment === "left" && fontSizeHeading7)
-            }
-            lineHeight={this.paragraphLineHeight}
+        {({ measureRef }) => (
+          <header
+            className="ProfileHeader"
+            ref={measureRef}
             style={[
-              styles.textBodySmall,
-              styles.intro.default,
-              styles.intro[alignment],
+              styles.header[alignment],
+              style,
             ]}
           >
-            {intro}
-          </ProfileIntro>
-        }
+            <div style={styles.flexContainer[alignment]}>
+              {avatarSrc &&
+                <Avatar
+                  src={avatarSrc}
+                  alt={`Avatar for user ${name}`}
+                  size={80}
+                  className="ProfileHeader-avatar"
+                  style={styles.avatar[alignment]}
+                />
+              }
 
-        {interests && interests.length > 0 &&
-          <TagList
-            style={styles.tagList[alignment]}
-            limit={interestsLimit}
-            rows={10}
-          >
-            {interests.map((interest) => (
-              <Tag key={interest}>{interest}</Tag>
-            ))}
-          </TagList>
-        }
-      </header>
+              <div style={styles.textContainer[alignment]}>
+                {location &&
+                  <LocationLabel style={styles.locationLabel[alignment]}>
+                    {location}
+                  </LocationLabel>
+                }
+
+                {name &&
+                  <Heading
+                    level={1}
+                    size={5}
+                    weight="medium"
+                    style={styles.heading}
+                  >
+                    {name}
+                  </Heading>
+                }
+
+                {website && validateUrl(website) &&
+                  <p
+                    style={[
+                      styles.textBodySmall,
+                      styles.website.default,
+                      styles.website[alignment],
+                    ]}
+                  >
+                    <a
+                      href={website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {urlParser(website).hostname.replace("www.", "")}
+                    </a>
+                  </p>
+                }
+              </div>
+            </div>
+
+            {intro &&
+              <ProfileIntro
+                maxLines={3}
+                fontSize={
+                  (alignment === "center" && fontSizeBodySmall) ||
+                  (alignment === "left" && fontSizeHeading7)
+                }
+                lineHeight={this.paragraphLineHeight}
+                style={[
+                  styles.textBodySmall,
+                  styles.intro.default,
+                  styles.intro[alignment],
+                ]}
+              >
+                {intro}
+              </ProfileIntro>
+            }
+
+            {interests && interests.length > 0 &&
+              <TagList
+                style={styles.tagList[alignment]}
+                limit={interestsLimit}
+                rows={10}
+              >
+                {interests.map((interest) => (
+                  <Tag key={interest}>{interest}</Tag>
+                ))}
+              </TagList>
+            }
+          </header>
+        )}
+      </Measure>
     );
   }
 }
@@ -248,7 +268,6 @@ ProfileHeader.propTypes = {
   location: PropTypes.string,
   interests: PropTypes.arrayOf(PropTypes.string),
   interestsLimit: PropTypes.number,
-  alignment: PropTypes.oneOf(["center", "left"]),
   style: propTypes.style,
 };
 
@@ -258,7 +277,6 @@ ProfileHeader.defaultProps = {
   avatarSrc: "",
   location: "",
   interests: [],
-  alignment: "center",
   style: null,
 };
 

--- a/src/components/profileIntro/index.jsx
+++ b/src/components/profileIntro/index.jsx
@@ -1,0 +1,163 @@
+import React from "react";
+import PropTypes from "prop-types";
+import radium from "radium";
+import MarkdownRenderer from "react-markdown-renderer";
+import Measure from "react-measure";
+import cn from "classnames";
+import MoreLink from "../moreLink";
+import colors from "../../styles/colors";
+import { fontSizeBodySmall } from "../../styles/typography";
+import { rgba } from "../../utils/color";
+import propTypes from "../../utils/propTypes";
+
+class ProfileHeaderIntro extends React.Component {
+  static markup = (htmlContent) => ({ __html: htmlContent });
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      expanded: false,
+      maxHeight: (props.lineHeight * props.maxLines),
+      dimensions: {
+        height: -1,
+      },
+    };
+
+    this.toggleExpandedState = this.toggleExpandedState.bind(this);
+  }
+
+  toggleExpandedState() {
+    this.setState({
+      expanded: !this.state.expanded,
+    });
+  }
+
+  render() {
+    const {
+      children,
+      maxLines,
+      fontSize,
+      lineHeight,
+      style,
+    } = this.props;
+
+    const {
+      expanded,
+      maxHeight,
+      dimensions,
+    } = this.state;
+
+    const dangerousStyles = `
+      .ProfileHeaderIntro .ClampedText img,
+      .ProfileHeaderIntro .ClampedText video,
+      .ProfileHeaderIntro .ClampedText iframe {
+        display: none !important;
+      }
+
+      .ProfileHeaderIntro .ClampedText:not(.expanded) {
+        display: block;
+        display: -webkit-box;
+        height: calc(1em * ${(lineHeight / fontSize)} * ${maxLines});
+        line-height: ${(lineHeight / fontSize)};
+        overflow: hidden;
+        padding: 0;
+        position: relative;
+        text-overflow: ellipsis;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: ${maxLines};
+      }
+
+      .ProfileHeaderIntro .ClampedText:not(.expanded)::after {
+        background: linear-gradient(to right, ${rgba(colors.bgPrimary, 0)}, ${rgba(colors.bgPrimary, 1)} 75%);
+        bottom: 0;
+        content: "…";
+        display: block;
+        height: calc(1em * ${(lineHeight / fontSize)});
+        position: absolute;
+        right: 0;
+        text-align: right;
+        width: 10%;
+      }
+
+      @supports (-webkit-line-clamp: ${maxLines}) {
+        .ProfileHeaderIntro .ClampedText:not(.expanded)::after {
+          display: none !important;
+        }
+      }
+    `;
+
+    return (
+      <Measure
+        bounds
+        onResize={(contentRect) => {
+          this.setState({
+            dimensions: contentRect.bounds,
+          });
+        }}
+      >
+        {({ measureRef }) => (
+          <div
+            className="ProfileHeaderIntro"
+            style={[
+              {
+                fontSize: `${fontSize}px`,
+                lineHeight: (lineHeight / fontSize),
+              },
+              style,
+            ]}
+          >
+            <style
+              dangerouslySetInnerHTML={ProfileHeaderIntro.markup(dangerousStyles)}
+            />
+
+            <div
+              className={cn("ClampedText", expanded && "expanded")}
+              ref={node => { this.clampedText = node; }}
+            >
+              <article>
+                <div
+                  className="MarkdownContainer"
+                  ref={measureRef}
+                >
+                  <MarkdownRenderer
+                    className="MarkdownRender"
+                    markdown={children}
+                  />
+                </div>
+              </article>
+            </div>
+
+            {dimensions.height > maxHeight &&
+              <MoreLink
+                caps
+                size="small"
+                hideIcon
+                onClick={this.toggleExpandedState}
+              >
+                {expanded ? "Read less" : "Read more"}
+              </MoreLink>
+            }
+          </div>
+        )}
+      </Measure>
+    );
+  }
+}
+
+ProfileHeaderIntro.propTypes = {
+  children: PropTypes.node.isRequired,
+  maxLines: PropTypes.number,
+  fontSize: PropTypes.number,
+  lineHeight: PropTypes.number,
+  style: propTypes.style,
+};
+
+ProfileHeaderIntro.defaultProps = {
+  maxLines: 3,
+  fontSize: fontSizeBodySmall,
+  lineHeight: 24,
+  style: null,
+};
+
+export default radium(ProfileHeaderIntro);

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -1774,6 +1774,26 @@ storiesOf("Profile header", module)
         center: "Center",
       }, "center")}
     />
+  ))
+  .add("With Markdown", () => (
+    <ProfileHeader
+      avatarSrc={text("Avatar URL", "https://img2.wikia.nocookie.net/__cb20111018235020/muppet/images/thumb/1/14/Rizzo11.png/300px-Rizzo11.png")}
+      name={text("Name", "Rizzo the Rat")}
+      location={text("Location", "Ottawa, Ontario")}
+      website={text("Website URL", "https://www.lonelyplanet.com")}
+      intro={text("Introduction", "# Heading \n* List item 1 \n* List item 2 \n* List item 3 \nThe very basic core of a woman’s living spirit is her passion for adventure. \n### Heading \nThe joy of life comes from our encounters with new experiences, and hence there is no greater joy than to have an endlessly changing horizon.")}
+      interests={array("Interests", [
+        "Family",
+        "Shopping",
+        "Adventure",
+        "Art and architecture",
+        "Food",
+      ])}
+      alignment={select("Alignment", {
+        left: "Left",
+        center: "Center",
+      }, "center")}
+    />
   ));
 
 storiesOf("Promoted guidebook", module)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,6 +2881,10 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-node-dimensions@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/get-node-dimensions/-/get-node-dimensions-1.2.2.tgz#7a71e8624cf9e1ab74599bb05b7e5116e995e45b"
+
 get-pkg-repo@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz#43c6b4c048b75dd604fc5388edecde557f6335df"
@@ -4991,6 +4995,14 @@ react-measure@^0.4.0:
   dependencies:
     element-resize-detector "^1.1.5"
 
+react-measure@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-2.0.2.tgz#072a9a5fafc01dfbadc1fa5fb09fc351037f636c"
+  dependencies:
+    get-node-dimensions "^1.2.0"
+    prop-types "^15.5.10"
+    resize-observer-polyfill "^1.4.2"
+
 react-modal@^1.6.5, react-modal@^1.7.6, react-modal@^1.7.7:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-1.7.7.tgz#70205f51c58708c487aff681ba3fed7946e391d9"
@@ -5064,9 +5076,9 @@ react-router@^2.8.1:
     loose-envify "^1.2.0"
     warning "^3.0.0"
 
-react-scroll@^1.4.4:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.5.2.tgz#f10f14840d3138a121d2c0f04933bbfee4193975"
+react-scroll@~1.5.2:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.5.5.tgz#52410d856e19a4259b98d0632df3a47df59036ba"
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.5.8"
@@ -5367,6 +5379,10 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+resize-observer-polyfill@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.4.2.tgz#a37198e6209e888acb1532a9968e06d38b6788e5"
 
 resolve-from@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
* Use react-measure to create element query and allow component to control its own layout; replaces `alignment` prop which has been removed
* Create ProfileIntro component, which contains expand/collapse and markdown rendering; also uses react-measure to decide when to show "read more" link, which replaces `window.resize` and `componentDidMount` stuff