### PR TITLE
fix: make flight widget arrow centered

### DIFF
--- a/src/components/flightSearchWidget/index.jsx
+++ b/src/components/flightSearchWidget/index.jsx
@@ -104,7 +104,7 @@ class FlightSearchWidget extends Component {
       icon: {
         display: (width <= 182 && "none") || null,
         fontSize: `${(28 / fontSizeHeading4)}em`,
-        marginLeft: width <= 400 ? "16px" : "24px",
+        marginLeft: width <= 400 ? "16px" : "36px",
         stroke: colors.bgPrimary,
         strokeWidth: "2px",
         verticalAlign: "top",


### PR DESCRIPTION
moves arrow to be centered between departure and arrival locations