### PR TITLE
Refactor SectionHeader component

### DIFF
--- a/src/components/sectionHeader/index.jsx
+++ b/src/components/sectionHeader/index.jsx
@@ -59,8 +59,6 @@ class SectionHeader extends React.Component {
     const { width } = this.state.dimensions;
     const { children, theme, style } = this.props;
 
-    console.log(width);
-
     return (
       <Measure
         bounds

--- a/src/components/sectionHeader/index.jsx
+++ b/src/components/sectionHeader/index.jsx
@@ -4,11 +4,7 @@ import radium from "radium";
 import Measure from "react-measure";
 import { Heading } from "../text";
 import colors from "../../styles/colors";
-import {
-  fontSizeHeading2,
-  fontSizeHeading4,
-  lineHeightHeading4,
-} from "../../styles/typography";
+import { fontSizeHeading2 } from "../../styles/typography";
 import propTypes from "../../utils/propTypes";
 
 const styles = {
@@ -74,15 +70,11 @@ class SectionHeader extends React.Component {
             innerRef={measureRef}
             weight="regular"
             level={2}
-            size={2}
+            size={width < 600 ? 4 : 2}
             style={[
               styles.heading,
               styles.theme[theme].heading,
               style,
-              width < 600 && {
-                fontSize: `${fontSizeHeading4}px`,
-                lineHeight: lineHeightHeading4,
-              },
             ]}
           >
             {children}

--- a/src/components/sectionHeader/index.jsx
+++ b/src/components/sectionHeader/index.jsx
@@ -1,94 +1,118 @@
 import React from "react";
 import PropTypes from "prop-types";
 import radium from "radium";
-import Heading from "../heading";
-import { color, media } from "../../../settings.json";
+import Measure from "react-measure";
+import { Heading } from "../text";
+import colors from "../../styles/colors";
+import {
+  fontSizeHeading2,
+  fontSizeHeading4,
+  lineHeightHeading4,
+} from "../../styles/typography";
+import propTypes from "../../utils/propTypes";
 
 const styles = {
-  container: {
-    textAlign: "center",
-    marginBottom: "40px",
-    [`@media (min-width: ${media.min["720"]})`]: {
-      marginBottom: "64px",
-    },
-  },
-
   heading: {
-    marginBottom: "16px",
-    lineHeight: 1.3,
-    fontSize: "28px",
-
-    [`@media (min-width: ${media.min["720"]})`]: {
-      fontSize: "45px",
-    },
+    textAlign: "center",
   },
 
   divider: {
-    width: "30px",
-    borderStyle: "solid",
-    borderWidth: "1px",
-    marginBottom: "32px",
+    display: "block",
+    height: "2px",
+    marginLeft: "auto",
+    marginRight: "auto",
+    marginTop: `${16 / fontSizeHeading2}em`,
+    width: `${32 / fontSizeHeading2}em`,
   },
+
   theme: {
     default: {
       divider: {
-        borderColor: color.red,
+        backgroundColor: colors.accentRed,
       },
     },
+
     light: {
       divider: {
-        borderColor: color.white,
+        backgroundColor: "currentColor",
       },
+
       heading: {
-        color: color.white,
+        color: colors.textOverlay,
       },
     },
   },
 };
 
+class SectionHeader extends React.Component {
+  constructor(props) {
+    super(props);
 
-const SectionHeader = ({ children, heading, theme, style }) => {
-  heading = heading || {};
-  heading.size = heading.size || "large";
-  heading.weight = heading.weight || "extraThin";
+    this.state = {
+      dimensions: {
+        width: -1,
+      },
+    };
+  }
 
-  return (
-    <header
-      className="SectionHeader"
-      style={[styles.container, style]}
-    >
-      <Heading
-        {...heading}
-        override={[styles.heading, styles.theme[theme].heading]}
+  render() {
+    const { width } = this.state.dimensions;
+    const { children, theme, style } = this.props;
+
+    console.log(width);
+
+    return (
+      <Measure
+        bounds
+        onResize={(contentRect) => {
+          this.setState({
+            dimensions: contentRect.bounds,
+          });
+        }}
       >
-        {children}
-      </Heading>
+        {({ measureRef }) => (
+          <Heading
+            className="SectionHeader"
+            innerRef={measureRef}
+            weight="regular"
+            level={2}
+            size={2}
+            style={[
+              styles.heading,
+              styles.theme[theme].heading,
+              style,
+              width < 600 && {
+                fontSize: `${fontSizeHeading4}px`,
+                lineHeight: lineHeightHeading4,
+              },
+            ]}
+          >
+            {children}
 
-      <hr style={[styles.divider, styles.theme[theme].divider]} />
-    </header>
-  );
-};
+            <span
+              style={[
+                styles.divider,
+                styles.theme[theme].divider,
+              ]}
+            />
+          </Heading>
+        )}
+      </Measure>
+    );
+  }
+}
 
 SectionHeader.propTypes = {
   children: PropTypes.node.isRequired,
-  heading: PropTypes.shape(Heading.propTypes),
   theme: PropTypes.oneOf([
     "default",
     "light",
-  ]).isRequired,
-  style: PropTypes.objectOf(
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.object,
-    ]),
-  ),
+  ]),
+  style: propTypes.style,
 };
 
 SectionHeader.defaultProps = {
   theme: "default",
 };
-
-SectionHeader.styles = styles;
 
 export default radium(SectionHeader);

--- a/src/components/text/textHeading.jsx
+++ b/src/components/text/textHeading.jsx
@@ -19,6 +19,7 @@ const Heading = ({
   level,
   size,
   weight,
+  innerRef,
   className,
   id,
   style,
@@ -40,6 +41,7 @@ const Heading = ({
     <Element
       className={className}
       id={id}
+      ref={innerRef}
       style={[
         {
           color: colors.textPrimary,
@@ -60,6 +62,7 @@ Heading.propTypes = {
   level: propTypes.heading,
   size: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8]),
   weight: propTypes.fontWeight,
+  innerRef: PropTypes.func,
   className: PropTypes.string,
   id: PropTypes.string,
   style: propTypes.style,
@@ -69,6 +72,7 @@ Heading.defaultProps = {
   level: 2,
   size: 2,
   weight: "regular",
+  innerRef: null,
   className: null,
   id: null,
   style: null,

--- a/src/components/text/textHeading.jsx
+++ b/src/components/text/textHeading.jsx
@@ -69,6 +69,9 @@ Heading.defaultProps = {
   level: 2,
   size: 2,
   weight: "regular",
+  className: null,
+  id: null,
+  style: null,
 };
 
 export default radium(Heading);

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -177,6 +177,7 @@ import { Typeahead, TypeaheadTokenizer } from "../src/components/typeahead";
 import TypeSelector from "../src/components/typeSelector";
 import VideoEmbed from "../src/components/videoEmbed";
 import WatchLaterModal from "../src/components/watchLater/watchLaterModal";
+import colorTokens from "../src/styles/colors";
 
 storiesOf("Styles", module)
   .addDecorator(withKnobs)
@@ -1966,11 +1967,18 @@ storiesOf("Sectional nav", module)
 storiesOf("Section Header", module)
   .addDecorator(withKnobs)
   .add("Default", () => (
-    <StyleRoot>
+    <Center grow>
       <SectionHeader theme={select("Theme", ["default", "light"], "default")}>
         {text("title", "Top experiences in Vietnam")}
       </SectionHeader>
-    </StyleRoot>
+    </Center>
+  ))
+  .add("Light", () => (
+    <Center backgroundColor={colorTokens.textPrimary} grow>
+      <SectionHeader theme={select("Theme", ["default", "light"], "light")}>
+        {text("title", "Top experiences in Vietnam")}
+      </SectionHeader>
+    </Center>
   ));
 
 storiesOf("Select", module)


### PR DESCRIPTION
This PR makes a few changes to the SectionHeader component.

* Replace media queries with react-measure. This allows for the component’s size to dictate its responsive styles instead of the window’s size. In turn, the component has been converted from functional to stateful because the dimensions provided by react-measure need to be handled within the component’s state.
* Remove containing `header` element. There is no reason for an extra container around the Heading component, so it has been removed.
* Use new TextHeading component and typography styles
* Change divider from `hr` to a `span`. Ideally, the divider would be build purely in CSS using pseudo elements; this change mimics that idea. 1. A pseudo element lives inside of it’s parent element, so the divider markup has been moved inside of Heading; this also allows for the sizing to be relative to the Heading’s font size. 2. A pseudo element has no semantic value, neither does a `span` and since the divider is presentational, the `hr` provides semantic value we don’t want.
* Remove heading object prop; since the component itself is now a Heading, we don’t need a separate prop to pass in an object of settings for the Heading. Furthermore, the Heading now has it’s props predetermined, i.e., size, level, weight. Previously, the SectionHeading could include any number of heading props, but now I think it’s better to limit the component to be specifically configured how it was designed; an h2, using our fontSizeHeading2 (4 for mobile) and regular weight. This will allow the component to be rendered consistently.
* These updates should not break any current implementation, however, any heading settings passed in will not be applied.