### PR TITLE
fix: allow pageHeader title to have external link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -205,6 +205,16 @@
       "integrity": "sha1-1xPPZ8whHeogRj0qC2YAXCIHDEs=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2575,8 +2585,8 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.1.1",
@@ -2605,8 +2615,8 @@
           "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
           "dev": true,
           "requires": {
-            "is-text-path": "1.0.1",
             "JSONStream": "1.3.1",
+            "is-text-path": "1.0.1",
             "lodash": "4.17.4",
             "meow": "3.7.0",
             "split2": "2.1.1",
@@ -5329,16 +5339,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -9409,15 +9409,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
@@ -9476,6 +9467,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.8.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/components/pageHeader/index.jsx
+++ b/src/components/pageHeader/index.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import radium from "radium";
-import { Link } from "react-router";
 import capitalize from "lodash/capitalize";
 import colors from "../../styles/colors";
+import Link from "../link";
 import mq from "../../styles/mq";
 import { fontSizeHeading3, lineHeightHeading3 } from "../../styles/typography";
 import { Heading, TextUppercase } from "../text";
@@ -98,21 +98,17 @@ const PageHeader = ({
     </span>
   );
 
-  const TypeText = (topChoice || stars > 0) ? type.toLowerCase() : _.capitalize(type);
+  const TypeText = topChoice || stars > 0 ? type.toLowerCase() : _.capitalize(type);
 
   const PlaceText = (
     <span key="placeText">
-      {neighborhood ?
-        `${TypeText} in the ${neighborhood} neighbourhood` :
-        `${TypeText} in ${place}`}
+      {neighborhood
+        ? `${TypeText} in the ${neighborhood} neighbourhood`
+        : `${TypeText} in ${place}`}
     </span>
   );
 
-  const StarText = stars > 0 && (
-    <span key="starRating">
-      {stars} star
-    </span>
-  );
+  const StarText = stars > 0 && <span key="starRating">{stars} star</span>;
 
   const straplineText = strapline || [TopChoiceText, " ", StarText, " ", PlaceText];
 
@@ -120,7 +116,9 @@ const PageHeader = ({
     <Link to={titleHref} style={blueLink()}>
       {title}
     </Link>
-  ) : title;
+  ) : (
+    title
+  );
 
   return (
     <header
@@ -132,36 +130,19 @@ const PageHeader = ({
         style,
       ]}
     >
-      {title &&
-        <TextUppercase
-          style={styles.title.base}
-        >
-          {TitleContent}
-        </TextUppercase>
-      }
+      {title && <TextUppercase style={styles.title.base}>{TitleContent}</TextUppercase>}
 
-      <Heading
-        level={1}
-        size={1}
-        weight="medium"
-        style={styles.heading.base}
-      >
+      <Heading level={1} size={1} weight="medium" style={styles.heading.base}>
         {heading}
       </Heading>
 
-      {(type || strapline) &&
-        <div
-          className="PageHeader-strapline"
-          style={styles.strapline.base}
-        >
-          <Strapline
-            size="small"
-            parent="pageHeader"
-          >
+      {(type || strapline) && (
+        <div className="PageHeader-strapline" style={styles.strapline.base}>
+          <Strapline size="small" parent="pageHeader">
             {straplineText}
           </Strapline>
         </div>
-      }
+      )}
     </header>
   );
 };
@@ -210,10 +191,7 @@ PageHeader.propTypes = {
   /**
    * Alignment for header text
    */
-  alignment: PropTypes.oneOf([
-    "",
-    "center",
-  ]),
+  alignment: PropTypes.oneOf(["", "center"]),
 
   /**
    * Whether or not to set a max width on the header


### PR DESCRIPTION
narrative pageHeaders title links go to DN pages so this component needs to swap out react-router link for an `<a>` when a fully qualified url is provided