### PR TITLE
Let video playlist container height be auto

### DIFF
--- a/src/components/video/videoPlaylist.jsx
+++ b/src/components/video/videoPlaylist.jsx
@@ -51,7 +51,7 @@ const styles = {
 
   playlistContainer: {
     flexShrink: 0,
-    height: "100%",
+    height: "auto",
     position: "relative",
     right: 0,
     top: 0,


### PR DESCRIPTION
Fixes a bug in copilot where height is 0 and playlist is not visible.

![image](https://user-images.githubusercontent.com/1479563/34787720-e310a624-f5fd-11e7-8459-d0344d9516ce.png)
