### PR TITLE
feat: VideoPlaylistWithSlider.followVideoUrls prop added

### DIFF
--- a/src/components/card/cardAnchor.jsx
+++ b/src/components/card/cardAnchor.jsx
@@ -42,6 +42,7 @@ const styles = {
 const CardAnchor = ({
   children,
   href,
+  onClick,
   tabIndex,
   layout,
   spacing,
@@ -49,6 +50,7 @@ const CardAnchor = ({
 }) => (
   <Link
     to={href}
+    onClick={onClick}
     className="Card-anchor"
     tabIndex={tabIndex}
   >
@@ -67,7 +69,8 @@ const CardAnchor = ({
 
 CardAnchor.propTypes = {
   children: PropTypes.node.isRequired,
-  href: PropTypes.string.isRequired,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
   tabIndex: PropTypes.number,
   layout: PropTypes.oneOf(["tile", "card"]),
   spacing: PropTypes.oneOf(["normal", "compact"]),

--- a/src/components/card/cardImage.jsx
+++ b/src/components/card/cardImage.jsx
@@ -36,6 +36,7 @@ const imageSizes = {
 
 const CardImage = ({
   href,
+  onClick,
   src,
   aspectRatio,
   children,
@@ -52,6 +53,7 @@ const CardImage = ({
   >
     <Link
       to={href}
+      onClick={onClick}
       tabIndex={-1}
       style={styles.anchor}
     >
@@ -73,7 +75,8 @@ const CardImage = ({
 );
 
 CardImage.propTypes = {
-  href: PropTypes.string.isRequired,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
   src: PropTypes.string.isRequired,
   aspectRatio: PropTypes.oneOf([
     "video",

--- a/src/components/cardVideo/index.jsx
+++ b/src/components/cardVideo/index.jsx
@@ -121,14 +121,15 @@ const styles = {
 
 const CardVideo = ({
   href,
+  onClick,
   imageSrc,
   aspectRatio,
   actionIcon,
   actionIconLabel,
+  onClickActionIcon,
   runtime,
   heading,
   bullets,
-  onClick,
   layout,
   theme,
   spacing,
@@ -147,6 +148,7 @@ const CardVideo = ({
   >
     <CardImage
       href={href}
+      onClick={onClick}
       src={imageSrc}
       aspectRatio={aspectRatio}
       opacity={1}
@@ -190,13 +192,13 @@ const CardVideo = ({
             transitionDuration={timing.fast}
           />
 
-          {onClick &&
+          {onClickActionIcon &&
             <IconButton
               hoverBackgroundScale={1.2}
               shadow
               iconName={actionIcon}
               label={actionIconLabel}
-              onClick={onClick}
+              onClick={onClickActionIcon}
               style={[styles.button, styles.actionButton]}
               size={32}
               hoverColor={colors.textOverlay}
@@ -209,7 +211,7 @@ const CardVideo = ({
             <div
               style={[
                 styles.duration.default,
-                styles.duration[mobile || !onClick ? "bottomAligned" : "topAligned"],
+                styles.duration[mobile || !onClickActionIcon ? "bottomAligned" : "topAligned"],
               ]}
             >
               {duration(runtime)}
@@ -222,6 +224,7 @@ const CardVideo = ({
     <CardText>
       <CardAnchor
         href={href}
+        onClick={onClick}
         layout={layout}
         spacing={spacing}
       >
@@ -248,7 +251,8 @@ const CardVideo = ({
 );
 
 CardVideo.propTypes = {
-  href: PropTypes.string.isRequired,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
   imageSrc: PropTypes.string.isRequired,
   aspectRatio: PropTypes.oneOf([
     "video",
@@ -271,7 +275,7 @@ CardVideo.propTypes = {
   ]),
   actionIcon: PropTypes.string,
   actionIconLabel: PropTypes.string,
-  onClick: PropTypes.func,
+  onClickActionIcon: PropTypes.func,
   className: PropTypes.string,
   mobile: PropTypes.bool,
   style: propTypes.style,

--- a/src/components/video/videoPlaylist.jsx
+++ b/src/components/video/videoPlaylist.jsx
@@ -318,7 +318,7 @@ class VideoPlaylist extends Component {
                   <VideoFeatured
                     title={initialVideo.name}
                     description={initialVideo.description}
-                    runtime={initialVideo.duration}
+                    duration={initialVideo.duration}
                     image={initialVideo.image}
                     mobile={mobile}
                   />

--- a/src/components/video/videoPlaylist.jsx
+++ b/src/components/video/videoPlaylist.jsx
@@ -199,6 +199,7 @@ class VideoPlaylist extends Component {
   }
 
   onClickThumbnailVideo = (video) => {
+    this.hideFeaturedVideo();
     if (video.id !== this.state.video.id) {
       this.loadVideo({
         video,
@@ -266,8 +267,6 @@ class VideoPlaylist extends Component {
   }
 
   loadVideo = ({ video, play }) => {
-    this.hideFeaturedVideo();
-
     this.setState({
       video,
       play,

--- a/src/components/video/videoPlaylistWithSlider.jsx
+++ b/src/components/video/videoPlaylistWithSlider.jsx
@@ -73,9 +73,10 @@ class VideoPlaylistWithSlider extends React.Component {
   onLoadVideo = (video) => {
     this.setState({ video });
     if (!this.newPlaylist) {
+      console.log("this isn't a new playlist, so lets enable video info");
       this.setState({ enableVideoInfo: true });
     }
-
+    console.log("noting that this isn't a new playlist anymore");
     this.newPlaylist = false;
   }
 
@@ -99,6 +100,8 @@ class VideoPlaylistWithSlider extends React.Component {
     } = this.props;
 
     const { video, enableVideoInfo } = this.state;
+
+    console.log("rendering");
 
     return (
       <div className="VideoPlaylistWithSlider" style={style}>

--- a/src/components/video/videoPlaylistWithSlider.jsx
+++ b/src/components/video/videoPlaylistWithSlider.jsx
@@ -73,10 +73,8 @@ class VideoPlaylistWithSlider extends React.Component {
   onLoadVideo = (video) => {
     this.setState({ video });
     if (!this.newPlaylist) {
-      console.log("this isn't a new playlist, so lets enable video info");
       this.setState({ enableVideoInfo: true });
     }
-    console.log("noting that this isn't a new playlist anymore");
     this.newPlaylist = false;
   }
 
@@ -100,8 +98,6 @@ class VideoPlaylistWithSlider extends React.Component {
     } = this.props;
 
     const { video, enableVideoInfo } = this.state;
-
-    console.log("rendering");
 
     return (
       <div className="VideoPlaylistWithSlider" style={style}>

--- a/src/components/video/videoPlaylistWithSlider.jsx
+++ b/src/components/video/videoPlaylistWithSlider.jsx
@@ -47,11 +47,8 @@ class VideoPlaylistWithSlider extends React.Component {
     super(props);
 
     this.state = {
-      /**
-       * Initial video is not set as "active" so that the VideoInfo component
-       * doesn't initially render -- this is as designed.
-       */
-      activeVideo: null,
+      video: props.video,
+      enableVideoInfo: false,
     };
 
     this.newPlaylist = true;
@@ -66,26 +63,28 @@ class VideoPlaylistWithSlider extends React.Component {
     ) {
       // Assume a new playlist has been loaded and state should reset
       this.setState({
-        activeVideo: null,
+        video: nextProps.video,
+        enableVideoInfo: false,
       });
-
       this.newPlaylist = true;
     }
   }
 
   onLoadVideo = (video) => {
+    this.setState({ video });
     if (!this.newPlaylist) {
-      this.setState({
-        activeVideo: video,
-      });
+      this.setState({ enableVideoInfo: true });
     }
 
     this.newPlaylist = false;
   }
 
+  onClickVideo = (video) => {
+    this.setState({ video });
+  }
+
   render() {
     const {
-      video,
       videos,
       visibleVideosDesktop,
       visibleVideosMobile,
@@ -95,10 +94,11 @@ class VideoPlaylistWithSlider extends React.Component {
       sliderHeading,
       mobile,
       showVideoInfo,
+      followVideoUrls,
       style,
     } = this.props;
 
-    const { activeVideo } = this.state;
+    const { video, enableVideoInfo } = this.state;
 
     return (
       <div className="VideoPlaylistWithSlider" style={style}>
@@ -117,11 +117,10 @@ class VideoPlaylistWithSlider extends React.Component {
               />
             </Container>
 
-            {showVideoInfo && activeVideo &&
+            {showVideoInfo && enableVideoInfo &&
               <Container>
                 <VideoInfo
-                  visible={activeVideo}
-                  video={activeVideo}
+                  video={video}
                   fadeIn
                 />
               </Container>
@@ -140,12 +139,13 @@ class VideoPlaylistWithSlider extends React.Component {
                       heading={v.name}
                       runtime={v.duration}
                       imageSrc={v.cardImage}
-                      href={v.url}
+                      href={followVideoUrls && v.url}
+                      onClick={!followVideoUrls && (() => this.onClickVideo(v))}
                       layout="tile"
                       spacing="compact"
                       mobile={mobile}
                       actionIcon={v.cardActionIcon}
-                      onClick={v.cardOnClick}
+                      onClickActionIcon={v.cardOnClickActionIcon}
                     />
                   ))}
                 </CardShelfVideoSlider>
@@ -159,7 +159,8 @@ class VideoPlaylistWithSlider extends React.Component {
                     <ThumbnailListItem
                       key={v.id}
                       title={v.name}
-                      href={v.url}
+                      href={followVideoUrls && v.url}
+                      onClick={!followVideoUrls && (() => this.onClickVideo(v))}
                       imagePath={v.thumbnailImage}
                       subtitle={[duration(v.duration)]}
                       lineClamp={false}
@@ -188,7 +189,7 @@ const videoShape = {
   cardImage: PropTypes.string, // recommended dimensions: 430x250
   thumbnailImage: PropTypes.string, // recommended dimensions: 160x90
   cardActionIcon: PropTypes.string,
-  cardOnClick: PropTypes.func,
+  cardOnClickActionIcon: PropTypes.func,
 };
 
 VideoPlaylistWithSlider.propTypes = {
@@ -205,6 +206,7 @@ VideoPlaylistWithSlider.propTypes = {
   }),
   mobile: PropTypes.bool,
   showVideoInfo: PropTypes.bool,
+  followVideoUrls: PropTypes.bool,
   style: propTypes.style,
 };
 

--- a/src/components/video/videoPopout.jsx
+++ b/src/components/video/videoPopout.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import radium, { Style } from "radium";
-import VideoEmbed from "../videoEmbed";
+import VideoEmbed from "./videoEmbed";
 import { Close } from "../icon";
 import colors from "../../styles/colors";
 import zIndex from "../../styles/zIndex";

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -870,7 +870,7 @@ storiesOf("Featured video", module)
   .add("Default", () => (
     <StyleRoot>
       <div style={{ width: "600px", height: "350px" }}>
-        <FeaturedVideo
+        <VideoFeatured
           videoId={text("Video ID", "5363317250001")}
           title={text("Title", "Introducing Italy")}
           description={text("Description", "Welcome to <b>italy</b>. <i>Come explore</i>.")}
@@ -889,7 +889,7 @@ storiesOf("Featured video", module)
   .add("Graphic", () => (
     <StyleRoot>
       <div style={{ width: "600px", height: "350px" }}>
-        <FeaturedVideo
+        <VideoFeatured
           videoId={text("Video ID", "5363317250001")}
           title={text("Title", "Introducing Italy")}
           image="https://lonelyplanetstatic.imgix.net/op-video-sync/images/production/p-5615400608001-brightcove-lonely-planets-best-destinations-to-visit-in-2018-20171028-052139.jpg?sharp=10&q=50&w=430&h=250&fit=crop"


### PR DESCRIPTION
By default `VideoPlaylistWithSlider` cards and thumbnails will all control the player's source.

The `followVideoUrls` prop can be used (set to true) to tell the component that cards and thumbnails should redirect the user to the `/video` player page instead of changing the source of the in-page player.

Also fixed a bug with the duration not properly being set on the `VideoFeatured` component within the `VideoPlaylist` component, which was also causing a weird loading glitch -- now fixed.