### PR TITLE
fix: Removed coverUp from VideoSlider

### DIFF
--- a/src/components/cardShelfVideoSlider/index.jsx
+++ b/src/components/cardShelfVideoSlider/index.jsx
@@ -169,7 +169,6 @@ class CardShelfVideoSlider extends React.Component {
       adSlot,
       theme,
       spacing,
-      sliderCoverupColor,
       style,
     } = this.props;
 
@@ -211,7 +210,6 @@ class CardShelfVideoSlider extends React.Component {
 
         <div style={styles.slider}>
           <VideoSlider
-            coverupColor={sliderCoverupColor}
             slidesToShow={4}
             infinite={false}
             arrows={!mobile}
@@ -262,14 +260,12 @@ CardShelfVideoSlider.propTypes = {
     "normal",
     "compact",
   ]),
-  sliderCoverupColor: PropTypes.string.isRequired,
   style: propTypes.style,
 };
 
 CardShelfVideoSlider.defaultProps = {
   theme: "light",
   spacing: "normal",
-  sliderCoverupColor: colors.bgPrimary,
 };
 
 export default radium(CardShelfVideoSlider);

--- a/src/components/video/videoSlider.jsx
+++ b/src/components/video/videoSlider.jsx
@@ -5,6 +5,7 @@ import IconButton from "../iconButton";
 import mq from "../../styles/mq";
 import timing from "../../styles/timing";
 import zIndex from "../../styles/zIndex";
+import propTypes from "../../utils/propTypes";
 
 const styles = {
   container: {
@@ -111,19 +112,6 @@ const styles = {
 
     prev: {
       left: "-2.2222em",
-    },
-  },
-
-  coverUp: {
-    height: "100%",
-    position: "absolute",
-    right: "-20px",
-    top: 0,
-    width: "20px",
-
-    [`@media (max-width: ${mq.max["480"]})`]: {
-      right: "-12px",
-      width: "12px",
     },
   },
 };
@@ -238,10 +226,10 @@ class VideoSlider extends React.Component {
     const {
       children,
       slidesToShow,
-      coverUpColor,
       infinite,
-      showArrows,
+      arrows,
       arrowProps,
+      style,
     } = this.props;
 
     const { index } = this.state;
@@ -257,9 +245,12 @@ class VideoSlider extends React.Component {
         className="VideoSlider"
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
-        style={styles.container}
+        style={[
+          styles.container,
+          style,
+        ]}
       >
-        {showArrows &&
+        {arrows &&
           <div
             style={[
               styles.arrowContainer,
@@ -283,7 +274,7 @@ class VideoSlider extends React.Component {
           </div>
         }
 
-        {showArrows &&
+        {arrows &&
           <div
             style={[
               styles.arrowContainer,
@@ -324,12 +315,6 @@ class VideoSlider extends React.Component {
           </div>
         </div>
 
-        <div
-          style={[
-            styles.coverUp,
-            { backgroundColor: coverUpColor },
-          ]}
-        />
       </div>
     );
   }
@@ -338,8 +323,7 @@ class VideoSlider extends React.Component {
 VideoSlider.propTypes = {
   children: PropTypes.arrayOf(PropTypes.element).isRequired,
   slidesToShow: PropTypes.oneOf([1, 2, 3, 4]),
-  coverUpColor: PropTypes.string,
-  showArrows: PropTypes.bool,
+  arrows: PropTypes.bool,
   arrowProps: PropTypes.shape({
     ...IconButton.propTypes,
     iconName: PropTypes.string,
@@ -349,14 +333,14 @@ VideoSlider.propTypes = {
   autoplay: PropTypes.bool,
   autoplaySpeed: PropTypes.number,
   pauseOnHover: PropTypes.bool,
+  style: propTypes.style,
 };
 
 VideoSlider.defaultProps = {
   slidesToShow: 4,
-  coverUpColor: "transparent",
   autoplaySpeed: 5000,
   pauseOnHover: true,
-  showArrows: true,
+  arrows: true,
   arrowProps: {},
 };
 

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -2304,59 +2304,6 @@ storiesOf("Setting Block", module)
     </div>
   ));
 
-storiesOf("Slider", module)
-  .addDecorator(withKnobs)
-  .add("Default", () => {
-    const styles = {
-      container: {
-        padding: "20px",
-      },
-      arrow: {
-        default: {
-          backgroundColor: "#1e7bcc",
-          color: "white",
-          paddingLeft: "6px",
-          position: "relative",
-          width: "20px",
-        },
-        next: {
-          right: "20px",
-        },
-      },
-      slide: {
-        backgroundColor: "black",
-        color: "white",
-      },
-    };
-    return (
-      <StyleRoot>
-        <div style={styles.container}>
-          <Slider
-            slidesToShow={number("Slides to show", 4, {
-               range: true,
-               min: 1,
-               max: 4,
-               step: 1,
-            })}
-            coverupColor={text("Coverup color", "transparent")}
-            infinite={boolean("Infinite", false)}
-            autoplay={boolean("Autoplay", false)}
-            autoplaySpeed={number("Autoplay speed", 5000)}
-            pauseOnHover={boolean("Pause on hover", true)}
-            arrows={boolean("Arrows", true)}
-          >
-            <div key="1" style={styles.slide}>Slide 1</div>
-            <div key="2" style={styles.slide}>Slide 2</div>
-            <div key="3" style={styles.slide}>Slide 3</div>
-            <div key="4" style={styles.slide}>Slide 4</div>
-            <div key="5" style={styles.slide}>Slide 5</div>
-            <div key="6" style={styles.slide}>Slide 6</div>
-          </Slider>
-        </div>
-      </StyleRoot>
-    );
-  });
-
 storiesOf("Sights List Item", module)
   .addDecorator(withKnobs)
   .add("Default", () => (
@@ -3274,7 +3221,6 @@ storiesOf("Video card shelf", module)
           href="/"
           theme={select("Theme", ["light", "dark"], "light")}
           spacing={select("Spacing", ["normal", "compact"], "compact")}
-          sliderCoverupColor={select("Slider coverup color", ["transparent", "white", "#1f1f1f"], "transparent")}
         >
           <CardVideo
             heading={text("Heading", "High Sierra ")}
@@ -3622,7 +3568,57 @@ storiesOf("Video playlist", module)
     </StyleRoot>
   ));
 
-
+  storiesOf("Video Slider", module)
+    .addDecorator(withKnobs)
+    .add("Default", () => {
+      const styles = {
+        container: {
+          padding: "20px",
+        },
+        arrow: {
+          default: {
+            backgroundColor: "#1e7bcc",
+            color: "white",
+            paddingLeft: "6px",
+            position: "relative",
+            width: "20px",
+          },
+          next: {
+            right: "20px",
+          },
+        },
+        slide: {
+          backgroundColor: "black",
+          color: "white",
+        },
+      };
+      return (
+        <StyleRoot>
+          <div style={styles.container}>
+            <VideoSlider
+              slidesToShow={number("Slides to show", 4, {
+                 range: true,
+                 min: 1,
+                 max: 4,
+                 step: 1,
+              })}
+              infinite={boolean("Infinite", false)}
+              autoplay={boolean("Autoplay", false)}
+              autoplaySpeed={number("Autoplay speed", 5000)}
+              pauseOnHover={boolean("Pause on hover", true)}
+              arrows={boolean("Arrows", true)}
+            >
+              <div key="1" style={styles.slide}>Slide 1</div>
+              <div key="2" style={styles.slide}>Slide 2</div>
+              <div key="3" style={styles.slide}>Slide 3</div>
+              <div key="4" style={styles.slide}>Slide 4</div>
+              <div key="5" style={styles.slide}>Slide 5</div>
+              <div key="6" style={styles.slide}>Slide 6</div>
+            </VideoSlider>
+          </div>
+        </StyleRoot>
+      );
+    });
 
 storiesOf("Video popout", module)
   .addDecorator(withKnobs)


### PR DESCRIPTION
_Also, renamed VideoSliders `showArrows` to `arrows` to match the react-slick props._

The "Coverup" was a `div` that hung off the edge of the slider that was intended to match the page background.  It was meant to cover up incoming cards as the slider slid.

But, the slider itself now has an `overflow: hidden` around it and you can't see the cards that are sliding into view anyway.

But, the main purpose for fixing this was because this is what the 100% width slider looked like on mobile (notice the right margin along the page):

![26941866_10112083778143554_1566546982_o](https://user-images.githubusercontent.com/3586751/35061939-aecebf84-fb90-11e7-84e8-65d4e32f2ebb.png)
