### PR TITLE
fix: Cue points break on mobile safari

### DIFF
--- a/src/components/video/videoEmbed.jsx
+++ b/src/components/video/videoEmbed.jsx
@@ -314,7 +314,7 @@ class VideoEmbed extends Component {
   }
 
   onPlayerLoadStart() {
-    this.player.textTracks().tracks_.forEach((tt) => {
+    this.getTextTracks().forEach((tt) => {
       tt.oncuechange = this.onPlayerCueChange.bind(this);
     });
 
@@ -578,12 +578,21 @@ class VideoEmbed extends Component {
     this.play();
   }
 
+  getTextTracks() {
+    if (!this.player) {
+      return [];
+    }
+
+    const textTracks = this.player.textTracks();
+    return [...Array(textTracks.length).keys()].map(i => textTracks[i]);
+  }
+
   getActiveCues() {
     const activeCues = [];
 
-    this.player.textTracks().tracks_.forEach((tt) => {
-      tt.activeCues_.forEach((c) => {
-        activeCues.push(c);
+    this.getTextTracks().forEach((tt) => {
+      [...Array(tt.activeCues.length).keys()].forEach((j) => {
+        activeCues.push(tt.activeCues[j]);
       });
     });
 


### PR DESCRIPTION
Basically replaced usage of videojs private variables (variables that end with `_`) with non-private variables.

For example:

`this.player.textTracks()` returns a "text tracks" object  -- not a list.
`this.player.textTracks().track_` is assumed to be a private variable and isn't present on all browsers.  It's a list, but not reliable.
`this.player.textTracks()[0]` DOES work... so basically just wrote a wrapper around that.