### PR TITLE
Transform Object.assign with Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react", "stage-1"],
-  "plugins": ["transform-decorators-legacy"]
+  "plugins": ["transform-decorators-legacy", "transform-object-assign"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1342,6 +1342,15 @@
         "babel-runtime": "6.25.0"
       }
     },
+    "babel-plugin-transform-object-assign": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
+      "integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.25.0"
+      }
+    },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "babel-cli": "^6.14.0",
     "babel-eslint": "^6.1.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-1": "^6.13.0",


### PR DESCRIPTION
This transpiles `Object.assign` for IE 11.

![image](https://user-images.githubusercontent.com/1479563/35286945-e5fd5c96-0026-11e8-99e1-3eb7f2d5fb39.png)
![image](https://user-images.githubusercontent.com/1479563/35286947-e7da68d8-0026-11e8-9a03-cb7d88a70e12.png)
