### PR TITLE
fix: Reduce lodash dependencies

### DIFF
--- a/src/components/iconButton/index.jsx
+++ b/src/components/iconButton/index.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import radium, { Style } from "radium";
-import { upperFirst, uniqueId } from "lodash";
+import upperFirst from "lodash/upperFirst";
+import uniqueId from "lodash/uniqueId";
 import cn from "classnames";
 import colors from "../../styles/colors";
 import timing from "../../styles/timing";

--- a/src/components/video/videoEmbed.jsx
+++ b/src/components/video/videoEmbed.jsx
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import radium, { Style } from "radium";
-import { get, uniqueId } from "lodash";
+import get from "lodash/get";
+import uniqueId from "lodash/uniqueId";
 import VideoUpNext from "./videoUpNext";
 import mq from "../../styles/mq";
 import timing from "../../styles/timing";


### PR DESCRIPTION
To reduce the bundle sizes of libraries that import backpack, we need to make sure to pull in individual pieces of lodash. Otherwise it will accidentally pull in the whole thing...

![](https://d.pr/i/tACxpx+)