### PR TITLE
VideoSlider draggable

### DIFF
--- a/src/components/cardShelfVideoSlider/index.jsx
+++ b/src/components/cardShelfVideoSlider/index.jsx
@@ -210,7 +210,6 @@ class CardShelfVideoSlider extends React.Component {
 
         <div style={styles.slider}>
           <VideoSlider
-            slidesToShow={4}
             infinite={false}
             arrows={!mobile}
             arrowProps={{
@@ -222,7 +221,7 @@ class CardShelfVideoSlider extends React.Component {
               ],
             }}
           >
-            {React.Children.map(children.slice(0, mobile ? 4 : children.length), (child, i) => (
+            {React.Children.map(children, (child, i) => (
               <div key={i}>
                 {child}
               </div>

--- a/src/components/cardShelfVideoSlider/index.jsx
+++ b/src/components/cardShelfVideoSlider/index.jsx
@@ -221,7 +221,7 @@ class CardShelfVideoSlider extends React.Component {
               ],
             }}
           >
-            {React.Children.map(children, (child, i) => (
+            {React.Children.map(children.slice(0, mobile ? 4 : children.length), (child, i) => (
               <div key={i}>
                 {child}
               </div>

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -2617,13 +2617,16 @@ storiesOf("Video components", module)
       <StyleRoot>
         <div style={styles.container}>
           <VideoSlider
-            slidesToShow={number("Slides to show", 4, {
+            mqSlidesToShow={number("Slides to show (using media queries)", 4, {
               range: true,
               min: 1,
               max: 4,
               step: 1,
             })}
+            slidesToShow={number("Slides to show")}
+            cellSpacing={number("Cell spacing")}
             infinite={boolean("Infinite", false)}
+            draggable={boolean("Draggable", false)}
             autoplay={boolean("Autoplay", false)}
             autoplaySpeed={number("Autoplay speed", 5000)}
             pauseOnHover={boolean("Pause on hover", true)}


### PR DESCRIPTION
Added the following properties to `VideoSlider` (for upcoming new player UI)

`slidesToShow` - override default media-query-driven slide count with hardcoded numerical pixel value
`mqSlidesToShow` - media-query-driven slide counts (This defaults to a maximum of `4`, but if `slidesToShow` is specified, `mqSlidesToShow` is completely ignored.
`draggable` - enables dragging (really it's just scrolling)
`cellSpacing` - override default media-query-driven cell spacing with hardcoded numerical pixel value
`childStyles` - any overrides to child/slide styles