### PR TITLE
Add button prop to bookmark list menu component

### DIFF
--- a/src/components/bookmarkListMenu/index.jsx
+++ b/src/components/bookmarkListMenu/index.jsx
@@ -97,6 +97,7 @@ class BookmarkListMenu extends React.Component {
       className,
       reveal,
       style,
+      button,
     } = this.props;
 
     const optionsId = "bookmark-list-menu-options";
@@ -108,14 +109,16 @@ class BookmarkListMenu extends React.Component {
         style={[styles.container, style]}
         ref={innerRef}
       >
-        {reveal ?
+        {!button && reveal &&
           <IconRevealButton
             id={`${id}-IconRevealButton`}
             icon={iconFromString(iconName)}
             label={iconLabel}
             onClick={this.toggleOptions}
           />
-          :
+        }
+
+        {!button && !reveal &&
           <IconButton
             onClick={this.toggleOptions}
             iconName={iconName}
@@ -125,6 +128,14 @@ class BookmarkListMenu extends React.Component {
             color={colors.textPrimary}
             backgroundColor={colors.bgPrimary}
           />
+        }
+
+        {button && !reveal &&
+          React.cloneElement(button, {
+            onClick: () => {
+              this.toggleOptions();
+            },
+          })
         }
 
         <div
@@ -166,6 +177,7 @@ BookmarkListMenu.propTypes = {
   className: PropTypes.string,
   reveal: PropTypes.bool,
   style: propTypes.style,
+  button: PropTypes.element,
 };
 
 BookmarkListMenu.defaultProps = {
@@ -173,6 +185,7 @@ BookmarkListMenu.defaultProps = {
   className: null,
   reveal: false,
   style: null,
+  button: null,
 };
 
 export default clickOutside(radium(BookmarkListMenu));

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -1748,6 +1748,24 @@ storiesOf("Popovers", module)
       </BookmarkListMenu>
     </Center>
   ))
+  .add("Bookmark list menu (custom button)", () => (
+    <Center>
+      <BookmarkListMenu
+        button={
+          <Button rounded border color="gray" size="tiny">
+            Share
+          </Button>
+        }
+      >
+        <BookmarkListMenuOption onClick={action("Edit click")}>Edit list</BookmarkListMenuOption>
+        <BookmarkListMenuOption onClick={action("Add click")}>Add new places</BookmarkListMenuOption>
+        <BookmarkListMenuOption onClick={action("Reorder click")}>Reorder places</BookmarkListMenuOption>
+        <BookmarkListMenuOption onClick={action("Share click")}>Share on Twitter</BookmarkListMenuOption>
+        <BookmarkListMenuOption onClick={action("Share click")}>Share on Facebook</BookmarkListMenuOption>
+        <BookmarkListMenuOption onClick={action("Copy click")}>Copy link</BookmarkListMenuOption>
+      </BookmarkListMenu>
+    </Center>
+  ))
   .add("Dialog", () => (
     <StyleRoot>
       <ModalWrapper>


### PR DESCRIPTION
Allows for a custom button element to be used instead of the icon buttons.

We will be able to build the share menu like designed on the new POI pages.

![image](https://user-images.githubusercontent.com/1479563/37110756-67924db8-2203-11e8-8c9b-0db73427c638.png)
