### PR TITLE
fix: popout player stretches entire height of browser window on IE 11

### DIFF
--- a/src/components/video/videoPopout.jsx
+++ b/src/components/video/videoPopout.jsx
@@ -40,7 +40,7 @@ const styles = {
     fixedToWindow: {
       bottom: "24px",
       boxShadow: `0px 1px 8px 0px ${rgba(colors.bgOverlay, 0.4)}`,
-      height: "initial",
+      height: "auto",
       maxWidth: "406px",
       position: "fixed",
       right: "24px",


### PR DESCRIPTION
Apparently IE 11 doesn't recognize `height: initial`
![capture4](https://user-images.githubusercontent.com/3586751/39149578-8cf4c728-470d-11e8-9820-aab425c7a633.PNG)
