### PR TITLE
fix: DOT-314 add height to overlay to prevent going off screen in iOS

### DIFF
--- a/src/components/overlay/index.jsx
+++ b/src/components/overlay/index.jsx
@@ -20,6 +20,7 @@ const styles = {
   overlay: {
     base: {
       bottom: 0,
+      height: "100vh",
       left: 0,
       position: "fixed",
       right: 0,


### PR DESCRIPTION
https://lonelyplanet.atlassian.net/browse/DOT-314

create and cancel buttons are pushed off screen in iOS, adding `height: 100vh` restricts the overlay to the viewport