### PR TITLE
Add ability to set the initial step of the multistep wrapper

### DIFF
--- a/src/components/multiStep/multiStepWrapper.jsx
+++ b/src/components/multiStep/multiStepWrapper.jsx
@@ -5,11 +5,17 @@ export default class MultiStepWrapper extends React.Component {
   static propTypes = {
     children: PropTypes.func.isRequired,
     totalSteps: PropTypes.number.isRequired,
-  }
-
-  state = {
-    currentStep: 1,
+    initialStep: PropTypes.number,
   };
+
+  constructor(props) {
+    super(props);
+    const { initialStep, totalSteps } = props;
+
+    this.state = {
+      currentStep: initialStep && initialStep <= totalSteps ? initialStep : 1,
+    };
+  }
 
   setCurrentStep(step) {
     this.setState({


### PR DESCRIPTION
This makes it possible to server side render the sign in form at the password prompt step after users enter an incorrect username or password. 

This will be used for Alexa's oAuth client, because they don't display errors sent to the callback handler.