### PR TITLE
fix: Pass an array to PropTypes.oneOf instead of multiple arguments

### DIFF
--- a/src/components/socialLoginButton/index.jsx
+++ b/src/components/socialLoginButton/index.jsx
@@ -84,11 +84,11 @@ const SocialLoginButton = (props) => {
 
 SocialLoginButton.propTypes = {
   children: PropTypes.string.isRequired,
-  iconName: PropTypes.oneOf(
+  iconName: PropTypes.oneOf([
     "FacebookBlockColor",
     "GoogleColor",
     "TwitterColor",
-  ).isRequired,
+  ]).isRequired,
   onClick: PropTypes.func,
   iconProps: PropTypes.objectOf(PropTypes.object),
   style: propTypes.style,


### PR DESCRIPTION
This should resolve this warning in the console.

> Warning: Invalid argument supplied to oneOf, expected an instance of array.
