### PR TITLE
fix: update sticky dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4927,11 +4927,6 @@
         "es5-ext": "0.10.39"
       }
     },
-    "eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
-    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -11808,14 +11803,36 @@
       }
     },
     "react-stickynode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-stickynode/-/react-stickynode-1.4.1.tgz",
-      "integrity": "sha512-V2ep9tgDcK3SLhVzz24OOFxOBMUz55lDM77m6tlstxc0mudQ9vx+RNBl9Tnt1Y96quSyNq0iZnEadviR2hDo9A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-stickynode/-/react-stickynode-2.0.1.tgz",
+      "integrity": "sha512-uTNAFsANMT9/CXZPQbi6bsxvL+q4CCf19rJh5OmJom8uyScBcSAjD1+d6I+Y4fT1s0iSQv8xbOjYcZmk2qAmsw==",
       "requires": {
         "classnames": "2.2.5",
         "prop-types": "15.6.0",
         "react-addons-shallow-compare": "15.6.2",
-        "subscribe-ui-event": "1.1.1"
+        "subscribe-ui-event": "2.0.1"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+          "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "subscribe-ui-event": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/subscribe-ui-event/-/subscribe-ui-event-2.0.1.tgz",
+          "integrity": "sha512-0/K8yRPewkNg+dBOZw2n/CtcNtI5lXHNbvWvjEi/pEyw4hEf7sSkTrW/RYwBju7lhThuMPe79wreBIAhQ0I2hw==",
+          "requires": {
+            "eventemitter3": "3.1.0",
+            "lodash": "4.17.10",
+            "raf": "3.4.0"
+          }
+        }
       }
     },
     "react-style-proptype": {
@@ -12874,16 +12891,6 @@
             "ajv": "5.5.2"
           }
         }
-      }
-    },
-    "subscribe-ui-event": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/subscribe-ui-event/-/subscribe-ui-event-1.1.1.tgz",
-      "integrity": "sha1-4OSqd9xIh0PucL/+uBN21TPUgG8=",
-      "requires": {
-        "eventemitter3": "2.0.3",
-        "lodash": "4.17.5",
-        "raf": "3.4.0"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-router": "^3.2.0",
     "react-scroll": "^1.7.7",
     "react-slick": "^0.18.0",
-    "react-stickynode": "^1.4.1",
+    "react-stickynode": "^2.0.1",
     "react-tether": "^0.6.0",
     "react-validate-form": "^1.0.6",
     "react-waypoint": "^7.3.4",


### PR DESCRIPTION
there is an issue on wp-travelnews related to the react-stickynode library. Updated to the newest version resolves this

https://lonelyplanet.atlassian.net/secure/RapidBoard.jspa?rapidView=2&modal=detail&selectedIssue=DOT-396