### PR TITLE
Make ReviewedBadge icon size relative

### DIFF
--- a/src/components/reviewedBadge/index.jsx
+++ b/src/components/reviewedBadge/index.jsx
@@ -15,8 +15,8 @@ const styles = {
   },
 
   icon: {
-    fontSize: "24px",
-    marginRight: "4px",
+    fontSize: `${24 / 18}em`,
+    marginRight: `${4 / 18}em`,
   },
 };
 


### PR DESCRIPTION
Allows the icon to size along with the text and maintain the correct proportions.