### PR TITLE
feat: allow ad children

### DIFF
--- a/src/components/ad/index.jsx
+++ b/src/components/ad/index.jsx
@@ -50,7 +50,7 @@ const styles = {
   },
 };
 
-function Ad({ id, framed, className, style }) {
+function Ad({ id, framed, className, style, children }) {
   const AdUnit = (
     <div
       className={cn("Ad", className)}
@@ -60,7 +60,7 @@ function Ad({ id, framed, className, style }) {
         framed && styles.ad.framed,
         style && style,
       ]}
-    />
+    >{children}</div>
   );
 
   if (framed) {
@@ -91,6 +91,7 @@ Ad.propTypes = {
   id: PropTypes.string.isRequired,
   framed: PropTypes.bool,
   className: PropTypes.string,
+  children: PropTypes.node,
   style: PropTypes.objectOf(
     PropTypes.oneOfType([
       PropTypes.string,

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -258,6 +258,19 @@ storiesOf("Ads", module)
         />
       </Center>
     </StyleRoot>
+  ))
+  .add("Ad Wrapper", () => (
+    <StyleRoot>
+      <Center>
+        <Ad
+          id={text("ID", "backpackAdIdentifier")}
+          framed={boolean("Framed", true)}
+          className={text("Class Name", "")}
+        >
+          <div>Add Children to the Ad to use the Ad Component as a Wrapper.</div>
+        </Ad>
+      </Center>
+    </StyleRoot>
   ));
 
 storiesOf("Authors", module)


### PR DESCRIPTION
Allow children to be descendants of Ad, so that it may be used as a style wrapper for Ad calls.

As an example, using `<Ad>` to wrap `amp-ad` components to have consistent styling and labeling.