### PR TITLE
feat: VideoPlaylist to show less overlay text

### DIFF
--- a/src/components/spotlightZone/index.jsx
+++ b/src/components/spotlightZone/index.jsx
@@ -234,7 +234,8 @@ const SpotlightZone = ({
           videoEmbed={{
             ...videoEmbed,
             vjsLP: {
-              showDetail: false,
+              showTitle: false,
+              showDescription: false,
               ...(videoEmbed.vjsLP || {}),
             },
           }}

--- a/src/components/video/videoEmbed.jsx
+++ b/src/components/video/videoEmbed.jsx
@@ -1065,7 +1065,9 @@ VideoEmbed.propTypes = {
   onMutedOverlayVisible: PropTypes.func,
   onMutedOverlayHidden: PropTypes.func,
   vjsLP: PropTypes.shape({
-    showDetail: PropTypes.bool,
+    showTitle: PropTypes.bool,
+    showDescription: PropTypes.bool,
+    showRelatedLocations: PropTypes.bool,
     showRelatedVideos: PropTypes.bool,
     showShareButton: PropTypes.bool,
     playlistReferenceId: PropTypes.string,

--- a/src/components/video/videoPlaylist.jsx
+++ b/src/components/video/videoPlaylist.jsx
@@ -375,6 +375,8 @@ class VideoPlaylist extends Component {
                   mobile,
                   onPlaySuccess: this.onPlaySuccess,
                   vjsLP: {
+                    showDescription: hideList,
+                    showRelatedLocations: hideList,
                     showRelatedVideos: hideList,
                     ...(videoEmbed.vjsLP || {}),
                   },
@@ -477,7 +479,7 @@ VideoPlaylist.propTypes = {
 
 VideoPlaylist.defaultProps = {
   heading: "Featured videos",
-  showFeaturedVideoCover: true,
+  showFeaturedVideoCover: false,
   mobile: false,
   hideList: false,
   videoPopout: {},

--- a/src/components/video/videoPlaylistWithSlider.jsx
+++ b/src/components/video/videoPlaylistWithSlider.jsx
@@ -143,7 +143,8 @@ class VideoPlaylistWithSlider extends React.Component {
                 videoEmbed={{
                   ...videoEmbed,
                   vjsLP: {
-                    showDetail: !(showVideoInfo && enableVideoInfo),
+                    showTitle: !(showVideoInfo && enableVideoInfo),
+                    showDescription: hideList && !(showVideoInfo && enableVideoInfo),
                     showShareButton: !(showVideoInfo && enableVideoInfo),
                     ...(videoEmbed.vjsLP || {}),
                   },
@@ -260,7 +261,7 @@ VideoPlaylistWithSlider.defaultProps = {
   heading: "Featured videos",
   visibleVideosDesktop: 12,
   visibleVideosMobile: 4,
-  showFeaturedVideoCover: true,
+  showFeaturedVideoCover: false,
   videoPopout: {},
   videoEmbed: {},
 };

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -2610,7 +2610,7 @@ storiesOf("Video components", module)
         heading={text("Heading", "Featured videos")}
         autoplay={boolean("Autoplay", false)}
         hideList={boolean("Hide list", false)}
-        showFeaturedVideoCover={boolean("Show featured video cover", true)}
+        showFeaturedVideoCover={boolean("Show featured video cover", false)}
         mobile={boolean("Mobile", false)}
         onLoadVideo={(video, autoplay) => { console.log("onLoadVideo:", video, autoplay); }}
         videos={[
@@ -2676,7 +2676,7 @@ storiesOf("Video components", module)
         hideList={boolean("Hide list", false)}
         autoplay={boolean("Autoplay", false)}
         showVideoInfo={boolean("Show video info", true)}
-        showFeaturedVideoCover={boolean("Show featured video cover", true)}
+        showFeaturedVideoCover={boolean("Show featured video cover", false)}
         mobile={boolean("Mobile", false)}
         onLoadVideo={(video, autoplay) => { console.log("onLoadVideo:", video, autoplay); }}
         videos={[


### PR DESCRIPTION
Video Playlists should only show the video title in it's overlay.   Previously, the video's description and a slider with related locations would be shown, but that alongside the video playlist is just too much text all over the place -- this is just an effort to clean things up visually for the user.