### PR TITLE
fix: add numbers to timing for modal closeTimeoutMS proptype error

### DIFF
--- a/src/components/modal/index.jsx
+++ b/src/components/modal/index.jsx
@@ -260,7 +260,7 @@ ModalComponent.defaultProps = {
   isOpen: false,
   desktopMaxHeight: "85vh",
   desktopWidth: "85%",
-  closeTimeoutMS: timing.default,
+  closeTimeoutMS: timing.numDefault,
   disableContentPadding: false,
   hideHeader: false,
 };

--- a/src/styles/timing.js
+++ b/src/styles/timing.js
@@ -2,4 +2,7 @@ export default {
   fast: "200ms",
   default: "400ms",
   slow: "800ms",
+  numFast: 200,
+  numDefault: 400,
+  numSlow: 800,
 };


### PR DESCRIPTION
react-modal requires a number be passed in for the timeout, not a string