### PR TITLE
feat: added muted overlay via videojs-lp support

### DIFF
--- a/src/components/video/videoEmbed.jsx
+++ b/src/components/video/videoEmbed.jsx
@@ -773,11 +773,16 @@ class VideoEmbed extends Component {
       return;
     }
 
-    this.setState({
-      showMutedOverlay: true,
-    });
+    if (this.hasLPUIPlugin()) {
+      this.player.lp().showMutedOverlay();
+      this.showMutedOverlay = false;
+    } else {
+      this.setState({
+        showMutedOverlay: true,
+      });
 
-    this.player.controls(false);
+      this.player.controls(false);
+    }
 
     if (this.props.onMutedOverlayVisible) {
       this.props.onMutedOverlayVisible();
@@ -789,11 +794,15 @@ class VideoEmbed extends Component {
       return;
     }
 
-    this.setState({
-      showMutedOverlay: false,
-    });
+    if (this.hasLPUIPlugin()) {
+      this.player.lp().hideMutedOverlay();
+    } else {
+      this.setState({
+        showMutedOverlay: false,
+      });
 
-    this.player.controls(true);
+      this.player.controls(true);
+    }
 
     if (this.props.onMutedOverlayHidden) {
       this.props.onMutedOverlayHidden();

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -2829,6 +2829,7 @@ storiesOf("Video components", module)
           whenAboveViewport={boolean("When above viewport", true)}
           whenBelowViewport={boolean("When below viewport", true)}
           mobile={boolean("Mobile", false)}
+          showCloseButton={boolean("Show close button", true)}
           videoEmbed={{
             videoId: "5615445675001",
             autoplay: true,


### PR DESCRIPTION
It looks like this:

<img width="231" alt="screen shot 2018-07-09 at 12 40 05 pm" src="https://user-images.githubusercontent.com/3586751/42467072-74a3d3d0-8376-11e8-8dac-545f176737c6.png">

I just never put it into backpack before because this functionality was only needed in rizzo-next at the time.