### PR TITLE
feat: added light theme to video playlist components

### DIFF
--- a/src/components/thumbnailListItem/index.jsx
+++ b/src/components/thumbnailListItem/index.jsx
@@ -47,7 +47,6 @@ const styles = {
       transition: `background-color ${timing.fast} linear, border-color ${timing.fast} linear`,
     },
     active: {
-      borderColor: colors.linkPrimary,
       backgroundColor: colors.linkPrimary,
     },
   },
@@ -98,7 +97,6 @@ const styles = {
     display: "flex",
     flexGrow: 1,
     justifyContent: "space-between",
-    // padding: "8px",
   },
 
   title: {
@@ -111,11 +109,9 @@ const styles = {
       transition: `color ${timing.default} ease`,
       WebkitBoxOrient: "vertical",
     },
-
     lineClamp: {
       WebkitLineClamp: 1,
     },
-
     light: {
       color: colors.textPrimary,
     },

--- a/src/components/thumbnailListItem/index.jsx
+++ b/src/components/thumbnailListItem/index.jsx
@@ -42,7 +42,14 @@ const hoverStyles = {
 
 const styles = {
   container: {
-    display: "flex",
+    default: {
+      display: "flex",
+      transition: `background-color ${timing.fast} linear, border-color ${timing.fast} linear`,
+    },
+    active: {
+      borderColor: colors.linkPrimary,
+      backgroundColor: colors.linkPrimary,
+    },
   },
 
   image: {
@@ -91,6 +98,7 @@ const styles = {
     display: "flex",
     flexGrow: 1,
     justifyContent: "space-between",
+    // padding: "8px",
   },
 
   title: {
@@ -111,8 +119,10 @@ const styles = {
     light: {
       color: colors.textPrimary,
     },
-
     dark: {
+      color: colors.textOverlay,
+    },
+    active: {
       color: colors.textOverlay,
     },
   },
@@ -190,7 +200,8 @@ const ThumbnailListItem = ({
   <div
     className={cn("ListItem-thumbnail", theme && `ListItem-thumbnail--${theme}`)}
     style={[
-      styles.container,
+      styles.container.default,
+      styles.container[theme],
       style,
     ]}
   >
@@ -303,7 +314,7 @@ ThumbnailListItem.propTypes = {
   onDescriptionIconClick: PropTypes.func,
   status: PropTypes.string,
   lineClamp: PropTypes.bool,
-  theme: PropTypes.oneOf(["light", "dark"]),
+  theme: PropTypes.oneOf(["light", "dark", "active"]),
   style: propTypes.style,
 };
 

--- a/src/components/video/videoPlaylist.jsx
+++ b/src/components/video/videoPlaylist.jsx
@@ -16,6 +16,8 @@ import zIndex from "../../styles/zIndex";
 import duration from "../../utils/time";
 import propTypes from "../../utils/propTypes";
 
+const lightBackgroundColor = colors.bgPrimary;
+const lightBorderColor = colors.borderPrimary;
 const darkBackgroundColor = "#1f1f1f";
 const darkBorderColor = "#2b2b2b";
 
@@ -64,57 +66,61 @@ const styles = {
   },
 
   playlistInner: {
-    backgroundColor: darkBackgroundColor,
-    display: "flex",
-    flexDirection: "column",
-    height: "100%",
-    left: 0,
-    position: "absolute",
-    top: 0,
-    width: "100%",
+    default: {
+      display: "flex",
+      flexDirection: "column",
+      height: "100%",
+      left: 0,
+      position: "absolute",
+      top: 0,
+      width: "100%",
+    },
+    light: {
+      backgroundColor: lightBackgroundColor,
+    },
+    dark: {
+      backgroundColor: darkBackgroundColor,
+    },
   },
 
   playlistHeader: {
-    backgroundColor: darkBackgroundColor,
-    borderColor: darkBorderColor,
-    borderStyle: "solid",
-    borderTopWidth: 0,
-    borderRightWidth: 0,
-    borderBottomWidth: "1px",
-    borderLeftWidth: 0,
-    color: colors.textOverlay,
-    fontSize: `${fontSizeHeading7}px`,
-    fontWeight: fontWeightLight,
-    letterSpacing: "1.5px",
-    lineHeight: lineHeightHeading7,
-    padding: "8px 16px",
-    textAlign: "center",
+    default: {
+      borderStyle: "solid",
+      borderTopWidth: 0,
+      borderRightWidth: 0,
+      borderBottomWidth: "1px",
+      borderLeftWidth: 0,
+      fontSize: `${fontSizeHeading7}px`,
+      fontWeight: fontWeightLight,
+      letterSpacing: "1.5px",
+      lineHeight: lineHeightHeading7,
+      padding: "8px 16px",
+      textAlign: "center",
+    },
+    light: {
+      color: colors.textPrimary,
+      backgroundColor: lightBackgroundColor,
+      borderColor: lightBorderColor,
+    },
+    dark: {
+      color: colors.textOverlay,
+      backgroundColor: darkBackgroundColor,
+      borderColor: darkBorderColor,
+    },
   },
 
   playlistItems: {
     overflowY: "auto",
   },
 
-  thumbnailListItem: {
-    default: {
-      backgroundColor: darkBackgroundColor,
-      borderColor: darkBorderColor,
-      borderStyle: "solid",
-      borderTopWidth: 0,
-      borderRightWidth: 0,
-      borderBottomWidth: "1px",
-      borderLeftWidth: 0,
-      cursor: "pointer",
-      paddingBottom: "8px",
-      paddingLeft: "8px",
-      paddingTop: "8px",
-      transition: `background-color ${timing.fast} linear, border-color ${timing.fast} linear`,
-    },
+  thumbnailListItemContainer: {
+    paddingLeft: "8px",
+    paddingRight: "8px",
+  },
 
-    active: {
-      backgroundColor: colors.linkPrimary,
-      borderColor: colors.linkPrimary,
-    },
+  thumbnailListItem: {
+    padding: "8px",
+    cursor: "pointer",
   },
 };
 
@@ -319,6 +325,7 @@ class VideoPlaylist extends Component {
   render() {
     const {
       heading,
+      theme,
       videos,
       visibleVideos,
       videoPopout,
@@ -389,6 +396,9 @@ class VideoPlaylist extends Component {
                 <Style
                   scopeSelector=".VideoPlaylist"
                   rules={{
+                    ".ListItem-thumbnail a": {
+                      color: "inherit !important",
+                    },
                     ".ListItem-thumbnail .Heading": {
                       fontWeight: "400 !important",
                     },
@@ -401,18 +411,34 @@ class VideoPlaylist extends Component {
                   }}
                 />
 
-                <div style={styles.playlistInner}>
-                  <div style={styles.playlistHeader}>
-                    {heading}
-                  </div>
+                <div
+                  style={[
+                    styles.playlistInner.default,
+                    styles.playlistInner[theme],
+                  ]}
+                >
+                  {heading &&
+                    <div
+                      style={[
+                        styles.playlistHeader.default,
+                        styles.playlistHeader[theme],
+                      ]}
+                    >
+                      {heading}
+                    </div>
+                  }
 
                   <div
                     ref={(childContainer) => { this.childContainer = childContainer; }}
                     style={styles.playlistItems}
                   >
-                    {videos.slice(0, visibleVideos || videos.length).map((v, i) => (
+                    {videos.slice(0, visibleVideos || videos.length).map((v) => (
                       <div
                         key={v.id}
+                        style={[
+                          styles.thumbnailListItemContainer,
+                          heading && { paddingTop: "8px" },
+                        ]}
                         ref={(ref) => { this.childRefs[v.id] = ref; }}
                       >
                         <ThumbnailListItem
@@ -420,16 +446,12 @@ class VideoPlaylist extends Component {
                           onClick={() => this.onClickThumbnailVideo(v)}
                           imagePath={v.thumbnailImage}
                           subtitle={[duration(v.duration)]}
-                          theme="dark"
+                          theme={v.id === video.id ? "active" : theme}
                           imageIcon={(v.id === video.id && "Play") || null}
                           imageIconLabel="Play"
                           lineClamp={false}
                           style={[
-                            styles.thumbnailListItem.default,
-                            v.id === video.id ? styles.thumbnailListItem.active : {},
-                            i === (
-                              (visibleVideos || videos.length) - 1 ? { borderBottomWidth: 0 } : {}
-                            ),
+                            styles.thumbnailListItem,
                             childStyles[v.id],
                           ]}
                         />
@@ -457,7 +479,8 @@ const videoShape = {
 };
 
 VideoPlaylist.propTypes = {
-  heading: PropTypes.string.isRequired,
+  heading: PropTypes.string,
+  theme: PropTypes.oneOf(["light", "dark"]),
   video: PropTypes.shape(videoShape),
   videos: PropTypes.arrayOf(PropTypes.shape(videoShape)),
   visibleVideos: PropTypes.number,
@@ -478,7 +501,7 @@ VideoPlaylist.propTypes = {
 };
 
 VideoPlaylist.defaultProps = {
-  heading: "Featured videos",
+  theme: "light",
   showFeaturedVideoCover: false,
   mobile: false,
   hideList: false,

--- a/src/components/video/videoPlaylist.jsx
+++ b/src/components/video/videoPlaylist.jsx
@@ -396,9 +396,6 @@ class VideoPlaylist extends Component {
                 <Style
                   scopeSelector=".VideoPlaylist"
                   rules={{
-                    ".ListItem-thumbnail a": {
-                      color: "inherit !important",
-                    },
                     ".ListItem-thumbnail .Heading": {
                       fontWeight: "400 !important",
                     },

--- a/src/components/video/videoPlaylistWithSlider.jsx
+++ b/src/components/video/videoPlaylistWithSlider.jsx
@@ -193,9 +193,7 @@ class VideoPlaylistWithSlider extends React.Component {
 
                 <div style={styles.listContainer}>
                   <Container>
-                    <ThumbnailList
-                      heading={sliderHeading || heading}
-                    >
+                    <ThumbnailList heading={sliderHeading || heading}>
                       {videos.slice(0, visibleVideosMobile).map((v) => (
                         <ThumbnailListItem
                           key={v.id}

--- a/src/components/video/videoPlaylistWithSlider.jsx
+++ b/src/components/video/videoPlaylistWithSlider.jsx
@@ -108,6 +108,7 @@ class VideoPlaylistWithSlider extends React.Component {
   render() {
     const {
       videos,
+      theme,
       visibleVideosDesktop,
       visibleVideosMobile,
       videoPopout,
@@ -131,6 +132,7 @@ class VideoPlaylistWithSlider extends React.Component {
             <Container style={styles.playlistContainer}>
               <VideoPlaylist
                 heading={heading}
+                theme={theme}
                 mobile={mobile}
                 video={video}
                 videos={videos}
@@ -191,7 +193,9 @@ class VideoPlaylistWithSlider extends React.Component {
 
                 <div style={styles.listContainer}>
                   <Container>
-                    <ThumbnailList heading={sliderHeading || heading}>
+                    <ThumbnailList
+                      heading={sliderHeading || heading}
+                    >
                       {videos.slice(0, visibleVideosMobile).map((v) => (
                         <ThumbnailListItem
                           key={v.id}
@@ -234,8 +238,9 @@ const videoShape = {
 
 VideoPlaylistWithSlider.propTypes = {
   video: PropTypes.shape(videoShape),
+  theme: PropTypes.oneOf(["light", "dark"]),
   videos: PropTypes.arrayOf(PropTypes.shape(videoShape)).isRequired,
-  heading: PropTypes.string.isRequired,
+  heading: PropTypes.string,
   sliderHeading: PropTypes.string,
   visibleVideosDesktop: PropTypes.number.isRequired,
   visibleVideosMobile: PropTypes.number.isRequired,
@@ -258,7 +263,7 @@ VideoPlaylistWithSlider.propTypes = {
 };
 
 VideoPlaylistWithSlider.defaultProps = {
-  heading: "Featured videos",
+  theme: "light",
   visibleVideosDesktop: 12,
   visibleVideosMobile: 4,
   showFeaturedVideoCover: false,

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -2658,6 +2658,7 @@ storiesOf("Video components", module)
     <StyleRoot>
       <VideoPlaylist
         heading={text("Heading", "Featured videos")}
+        theme={select("Theme", ["light", "dark"], "light")}
         autoplay={boolean("Autoplay", false)}
         hideList={boolean("Hide list", false)}
         showFeaturedVideoCover={boolean("Show featured video cover", false)}
@@ -2720,6 +2721,7 @@ storiesOf("Video components", module)
     <StyleRoot>
       <VideoPlaylistWithSlider
         heading={text("Heading", "Featured videos")}
+        theme={select("Theme", ["light", "dark"], "light")}
         sliderHeading={text("Slider heading", "Featured")}
         visibleVideosDesktop={number("Visible videos (desktop)", 6)}
         visibleVideosMobile={number("Visible videos (mobile)", 4)}

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -2356,7 +2356,7 @@ storiesOf("Video components", module)
         onDescriptionIconClick={action("Action for icon")}
         imageIcon={text("Image icon", "Play")}
         imageIconLabel={text("Image icon label", "Play")}
-        theme={select("Theme", ["light", "dark"], "light")}
+        theme={select("Theme", ["light", "dark", "active"], "light")}
       />
     </StyleRoot>
   ))


### PR DESCRIPTION
- New `theme` prop on `VideoPlaylist` and `VideoPlaylistWithSlider` ( can be set to `light` (default) or `dark`)
- `heading` prop on both those components is now optional
- Added `active` as a possible value for the `theme` prop on `ThumbnailListItem` component
- Updated borders and padding on playlist components as well

<img width="971" alt="screen shot 2018-07-18 at 11 16 18 am" src="https://user-images.githubusercontent.com/3586751/42890947-173cf8ea-8a7c-11e8-9d3d-524ed3fdcb4e.png">
<img width="969" alt="screen shot 2018-07-18 at 11 16 32 am" src="https://user-images.githubusercontent.com/3586751/42890948-19251b4c-8a7c-11e8-909f-6d7ed98874ff.png">
