### PR TITLE
feat: track newsletter subscriptions per AP spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -393,6 +393,28 @@
         }
       }
     },
+    "@lonelyplanet/lp-analytics": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@lonelyplanet/lp-analytics/-/lp-analytics-2.0.6.tgz",
+      "integrity": "sha512-zeDhctadOy22g2BOK49a05uFIclNYJflfxeP4gq8RNwiTW3j7IaIBZdLV9oJAOCvEYLqbS1gCNbLemy+F6Jf9w==",
+      "requires": {
+        "@types/react": "^16.4.18",
+        "@types/react-dom": "^16.0.9",
+        "devalue": "^1.0.4",
+        "react-helmet": "^5.2.0"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "16.4.18",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.18.tgz",
+          "integrity": "sha512-eFzJKEg6pdeaukVLVZ8Xb79CTl/ysX+ExmOfAAqcFlCCK5TgFDD9kWR0S18sglQ3EmM8U+80enjUqbfnUyqpdA==",
+          "requires": {
+            "@types/prop-types": "*",
+            "csstype": "^2.2.0"
+          }
+        }
+      }
+    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
@@ -667,14 +689,26 @@
     "@types/node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.1.tgz",
-      "integrity": "sha512-f+qQR5lLCB8UPhtk8Xm8RQvbR4ycD7MOsdiuAEQCYpz44bBx2g7JL0+iYBcjl9J7d0KT1sX2g0VGNeHfw+GXpg==",
-      "dev": true
+      "integrity": "sha512-f+qQR5lLCB8UPhtk8Xm8RQvbR4ycD7MOsdiuAEQCYpz44bBx2g7JL0+iYBcjl9J7d0KT1sX2g0VGNeHfw+GXpg=="
+    },
+    "@types/prop-types": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.6.tgz",
+      "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ=="
     },
     "@types/react": {
       "version": "16.0.38",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.38.tgz",
-      "integrity": "sha512-t0XJHNrlzLiVAKCWxS9zzAadoQO8zGFpHsrvNVk7QmrDXnm3cPFy2wFcHGNbKjntBiXznL6qQkh+a1Wxu21+dA==",
-      "dev": true
+      "integrity": "sha512-t0XJHNrlzLiVAKCWxS9zzAadoQO8zGFpHsrvNVk7QmrDXnm3cPFy2wFcHGNbKjntBiXznL6qQkh+a1Wxu21+dA=="
+    },
+    "@types/react-dom": {
+      "version": "16.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.9.tgz",
+      "integrity": "sha512-4Z0bW+75zeQgsEg7RaNuS1k9MKhci7oQqZXxrV5KUGIyXZHHAAL3KA4rjhdH8o6foZ5xsRMSqkoM5A3yRVPR5w==",
+      "requires": {
+        "@types/node": "*",
+        "@types/react": "*"
+      }
     },
     "JSONStream": {
       "version": "1.3.2",
@@ -4082,6 +4116,11 @@
         }
       }
     },
+    "csstype": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
+      "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw=="
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -4188,8 +4227,7 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -4282,6 +4320,11 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "devalue": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-1.1.0.tgz",
+      "integrity": "sha512-mKj+DaZuxevfmjI78VdlkBr+NDmwaDAKQz0t5RDSmhwBn6m5z82KDnVRKVFeUvlMOmI1fzkAUx4USdqGGhas6g=="
     },
     "diff": {
       "version": "3.2.0",
@@ -11861,6 +11904,17 @@
         "prop-types": "^15.5.9"
       }
     },
+    "react-helmet": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
+      "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.5.4",
+        "react-side-effect": "^1.1.0"
+      }
+    },
     "react-html-attributes": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.1.tgz",
@@ -12034,6 +12088,15 @@
       "requires": {
         "lodash.throttle": "^4.1.1",
         "prop-types": "^15.5.8"
+      }
+    },
+    "react-side-effect": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz",
+      "integrity": "sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==",
+      "requires": {
+        "exenv": "^1.2.1",
+        "shallowequal": "^1.0.1"
       }
     },
     "react-slick": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "url": "https://github.com/lonelyplanet/backpack-ui.git"
   },
   "dependencies": {
+    "@lonelyplanet/lp-analytics": "^2.0.6",
     "axios": "^0.15.3",
     "babel-plugin-transform-runtime": "^6.23.0",
     "chai": "^3.5.0",

--- a/src/components/newsletter/index.jsx
+++ b/src/components/newsletter/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import radium, { Style } from "radium";
 import axios from "axios";
 import Recaptcha from "react-recaptcha";
+import { analytics, getTrackMethod, EventNames } from "@lonelyplanet/lp-analytics";
 
 import colors from "../../styles/colors";
 import mq from "../../styles/mq";
@@ -144,6 +145,10 @@ class Newsletter extends Component {
       acceptLegalOptIn: false,
     };
 
+    this.track = () => null;
+    if (typeof window !== "undefined") {
+      this.track = getTrackMethod();
+    }
     this.handleInput = this.handleInput.bind(this);
     this.handleOptIn = this.handleOptIn.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -217,15 +222,18 @@ class Newsletter extends Component {
 
     axios
       .post(endpoint, data, config)
-      .then(response =>
+      .then(response => {
         this.setState({
           success: true,
           showSuccess: true,
           showCaptcha: false,
           response,
           waiting: false,
-        })
-      )
+        });
+        this.track({
+          [analytics.eventName]: EventNames.newsletterSubscription,
+        });
+      })
       .catch(error =>
         this.setState({
           success: false,


### PR DESCRIPTION
Imports `lp-analytics` and uses it to push a very simple event to the dataLayer whenever a newsletter subscription occurs.

Note that inclusion of `gtm.js` (and the actual tracking activity that its inclusion establishes) is up to the host codebase; this will only ensure that events are pushed to the `dataLayer` (which will be created if necessary). In the absence of `gtm.js` it's a plain ol' JS array. In the presence of `gtm.js` it's a patched array whose `.push` method also sends events along to gtm.
