### PR TITLE
fix: lock version of react-measure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11988,13 +11988,13 @@
       }
     },
     "react-measure": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.0.2.tgz",
-      "integrity": "sha1-ByqaX6/AHfutwfpfsJ/DUQN/Y2w=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.1.3.tgz",
+      "integrity": "sha512-KRgEs44mtilTm/7wEO4hWLbFRMeRioA10LUYIC+yLaM2Nv45M6qxo/oqyAUZukv6RcCIuiIiOXcay18qH3L5RA==",
       "requires": {
         "get-node-dimensions": "^1.2.0",
         "prop-types": "^15.5.10",
-        "resize-observer-polyfill": "^1.4.2"
+        "resize-observer-polyfill": "^1.5.0"
       }
     },
     "react-modal": {
@@ -12628,9 +12628,9 @@
       }
     },
     "resize-observer-polyfill": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
-      "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-date-range": "^0.9.4",
     "react-dates": "^12.7.1",
     "react-markdown-renderer": "^1.4.0",
-    "react-measure": "^2.0.2",
+    "react-measure": "2.1.3",
     "react-modal": "^3.2.1",
     "react-moment-proptypes": "^1.6.0",
     "react-motion": "^0.5.2",


### PR DESCRIPTION
I think this is breaking `destinations-next` builds.

Jenkins keeps throwing `Module not found: Error: Can't resolve '@babel/runtime/helpers/esm/objectWithoutPropertiesLoose' in '/mnt/workspace/destinations-next-branch-test/node_modules/react-measure/dist'`.

Seems like the same issue [cropped up](https://github.com/meteor/meteor/issues/10128#issuecomment-410523377) in several big-name JS projects this August, when Babel 7 was released.

 And `react-measure` [upgraded to Babel 7](https://github.com/souporserious/react-measure/commit/14e725e496fb0ac34f0ada7b011d134d4ee0872d#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L50) in a commit that was released with its version 2.2.

[`react-measure`](https://www.npmjs.com/package/react-measure/v/2.2.0) 2.2 was published 4 days ago at time of writing, which aligns with the timing of when Jenkins started breaking in `destinations-next`.

So,

### the solution:

lock `react-measure` to `2.1.3`, at least for now.

I suppose a better solution may be to update node & the Jenkins configuration in `destinations-next` to respect `package-lock.json`, but this is a quicker fix, and I wouldn't be surprised if `destinations-next` weren't the only victim of this issue.