### PR TITLE
fix: add optional prop for image alt text

### DIFF
--- a/src/components/articlePreview/index.jsx
+++ b/src/components/articlePreview/index.jsx
@@ -9,7 +9,7 @@ import Heading from "../heading";
 
 const markup = html => ({ __html: html });
 
-function ArticlePreview({ title, paragraph, image, href, category, categoryHref }) {
+function ArticlePreview({ title, paragraph, image, imageAlt, href, category, categoryHref }) {
   const styles = {
     container: {
       fontFamily: font("benton"),
@@ -55,7 +55,7 @@ function ArticlePreview({ title, paragraph, image, href, category, categoryHref 
     <article className="ArticlePreview" style={styles.container}>
       <figure className="ArticlePreview-image" style={styles.imageContainer}>
         <a href={href} style={styles.anchor}>
-          <img src={image} alt="" style={styles.image} />
+          <img src={image} alt={imageAlt} style={styles.image} />
         </a>
       </figure>
 
@@ -83,6 +83,7 @@ ArticlePreview.propTypes = {
   title: PropTypes.string.isRequired,
   paragraph: PropTypes.string.isRequired,
   image: PropTypes.string.isRequired,
+  imageAlt: PropTypes.string,
   href: PropTypes.string.isRequired,
   category: PropTypes.string.isRequired,
   categoryHref: PropTypes.string.isRequired,

--- a/src/components/articlePreview/index.jsx
+++ b/src/components/articlePreview/index.jsx
@@ -89,4 +89,8 @@ ArticlePreview.propTypes = {
   categoryHref: PropTypes.string.isRequired,
 };
 
+ArticlePreview.defaultProps = {
+  imageAlt: "",
+};
+
 export default ArticlePreview;

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -1397,6 +1397,7 @@ storiesOf("Lockups", module)
       title={text("Title", "New York’s most iconic buildings reimagined on deserted streets")}
       paragraph={text("Paragraph", "A new exhibition in New York of the city’s most &ldquo;iconic&rdquo; buildings shows them in a new light, with the bustle of modern life stripped out. Photographer")}
       image={text("Image URL", "http://placehold.it/410x230")}
+      imageAlt={text("Image Alt Text", "A new exhibition in New York of the city’s most iconic buildings.")}
       href={text("URL", "/")}
       category={text("Category name", "Art and culture")}
       categoryHref={text("Category URL", "/")}


### PR DESCRIPTION
Added optional prop for image alt text to the ArticlePreview component. This will help aid in accessibility of images.