### PR TITLE
fix: add webkit prefix for sticky nav

### DIFF
--- a/src/components/navigation/navigation.jsx
+++ b/src/components/navigation/navigation.jsx
@@ -35,7 +35,7 @@ const Navigation = (props) => {
       className="Navigation"
       style={[
         styles.nav,
-        sticky && { position: "sticky", top: 0 },
+        sticky && { position: "sticky", position: "-webkit-sticky", top: 0 }, // eslint-disable-line no-dupe-keys
         style,
       ]}
       {...properties}


### PR DESCRIPTION
"position: sticky;" needs an extra prefix that even autoprefixer doesn't set currently. Adding it manually here so that the "sticky" feature for the navigation component will work in Safari.