### PR TITLE
chore: add note in storybook about DateRange setup

### DIFF
--- a/src/components/form/daterange.jsx
+++ b/src/components/form/daterange.jsx
@@ -293,3 +293,23 @@ DateRange.defaultProps = {
 };
 
 export default radium(DateRange);
+
+export const DeveloperNote = () => (
+  /**
+   * A developer-facing note that is being written as a component
+   * for inclusion in storybook, which I figure gets more eyes than the readme.
+   */
+  <div style={{ margin: "32px" }}>
+    <em>Note to developers:</em>
+    <small style={{ display: "block" }}>
+      This component uses <a href="https://github.com/airbnb/react-dates">Airbnb's "react-dates" package/component</a>,
+      which requires some one-time global setup in order to properly load its styles.
+      You'll need to
+      <ul>
+        <li><a href="https://github.com/airbnb/react-dates#install-dependencies">install it as a dependency</a>,</li>
+        <li><a href="https://github.com/airbnb/react-dates#initialize">initialize the package</a>,</li>
+        <li>and then <a href="https://github.com/airbnb/react-dates#webpack">include its styles</a>.</li>
+      </ul>
+    </small>
+  </div>
+);

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -67,7 +67,7 @@ import CategoryLabelLink from "../src/components/categoryLabelLink";
 import Checkbox from "../src/components/checkbox";
 import Container from "../src/components/container";
 import ContentHeader from "../src/components/contentHeader";
-import DateRange from "../src/components/form/daterange";
+import DateRange, { DeveloperNote as DateRangeDeveloperNote} from "../src/components/form/daterange";
 import Dialog from "../src/components/dialog";
 import DisclaimerText from "../src/components/disclaimerText";
 import DotLoader from "../src/components/dotLoader";
@@ -843,50 +843,59 @@ storiesOf("Controls", module)
     />
   ))
   .add("Date range - without selection", () => (
-    <DateRange
-      id="testDateRange"
-      numberOfMonths={number("Number of Months", 1)}
-      startDatePlaceholderText={text("Start Date Placeholder", "Check-in")}
-      endDatePlaceholderText={text("End Date Placeholder", "Check-out")}
-      startDate={object("Start Date", null)}
-      endDate={object("End Date", null)}
-      lastSelectableDate={object("Last selectable date", moment().add(365, "days"))}
-      noBorder={boolean("noBorder", false)}
-      withFullScreenPortal={boolean("withFullScreenPortal", false)}
-      soldOut={boolean("soldOut", false)}
-      onDatesChange={action(event)}
-      onFocusChange={action(event)}
-    />
+    <React.Fragment>
+      <DateRange
+        id="testDateRange"
+        numberOfMonths={number("Number of Months", 1)}
+        startDatePlaceholderText={text("Start Date Placeholder", "Check-in")}
+        endDatePlaceholderText={text("End Date Placeholder", "Check-out")}
+        startDate={object("Start Date", null)}
+        endDate={object("End Date", null)}
+        lastSelectableDate={object("Last selectable date", moment().add(365, "days"))}
+        noBorder={boolean("noBorder", false)}
+        withFullScreenPortal={boolean("withFullScreenPortal", false)}
+        soldOut={boolean("soldOut", false)}
+        onDatesChange={action(event)}
+        onFocusChange={action(event)}
+      />
+      <DateRangeDeveloperNote />
+    </React.Fragment>
   ))
   .add("Date range - with just startDate selected", () => (
-    <DateRange
-      id="testDateRange"
-      numberOfMonths={number("Number of Months", 1)}
-      startDatePlaceholderText={text("Start Date Placeholder", "Check-in")}
-      endDatePlaceholderText={text("End Date Placeholder", "Check-out")}
-      startDate={object("Start Date", moment().add(1, "days"))}
-      endDate={object("End Date", null)}
-      noBorder={boolean("noBorder", false)}
-      withFullScreenPortal={boolean("withFullScreenPortal", false)}
-      soldOut={boolean("soldOut", false)}
-      onDatesChange={action(event)}
-      onFocusChange={action(event)}
-    />
+    <React.Fragment>
+      <DateRange
+        id="testDateRange"
+        numberOfMonths={number("Number of Months", 1)}
+        startDatePlaceholderText={text("Start Date Placeholder", "Check-in")}
+        endDatePlaceholderText={text("End Date Placeholder", "Check-out")}
+        startDate={object("Start Date", moment().add(1, "days"))}
+        endDate={object("End Date", null)}
+        noBorder={boolean("noBorder", false)}
+        withFullScreenPortal={boolean("withFullScreenPortal", false)}
+        soldOut={boolean("soldOut", false)}
+        onDatesChange={action(event)}
+        onFocusChange={action(event)}
+      />
+      <DateRangeDeveloperNote />
+    </React.Fragment>
   ))
   .add("Date range - with selection", () => (
-    <DateRange
-      id="testDateRange"
-      numberOfMonths={number("Number of Months", 1)}
-      startDatePlaceholderText={text("Start Date Placeholder", "Check-in")}
-      endDatePlaceholderText={text("End Date Placeholder", "Check-out")}
-      startDate={object("Start Date", moment().add(35, "days"))}
-      endDate={object("End Date", moment().add(36, "days"))}
-      noBorder={boolean("noBorder", false)}
-      withFullScreenPortal={boolean("withFullScreenPortal", false)}
-      soldOut={boolean("soldOut", false)}
-      onDatesChange={action(event)}
-      onFocusChange={action(event)}
-    />
+    <React.Fragment>
+      <DateRange
+        id="testDateRange"
+        numberOfMonths={number("Number of Months", 1)}
+        startDatePlaceholderText={text("Start Date Placeholder", "Check-in")}
+        endDatePlaceholderText={text("End Date Placeholder", "Check-out")}
+        startDate={object("Start Date", moment().add(35, "days"))}
+        endDate={object("End Date", moment().add(36, "days"))}
+        noBorder={boolean("noBorder", false)}
+        withFullScreenPortal={boolean("withFullScreenPortal", false)}
+        soldOut={boolean("soldOut", false)}
+        onDatesChange={action(event)}
+        onFocusChange={action(event)}
+      />
+      <DateRangeDeveloperNote />
+    </React.Fragment>
   ))
   .add("Dropdown", () => (
     <Dropdown


### PR DESCRIPTION
I spent some time Friday debugging `backpack-ui` and `destinations-x` styles before figuring out that the process described in this PR is what I needed to do to get everything working properly.

This documents the requisite setup for future devs.

As written in the comment, I figure that having the `DeveloperNote` displayed in `storybook` will more effectively propagate the message than would including it in the `README` (and there's generally all that blank space in storybook anyway, right?)

That said, I don't know of any precedent for doing this in storybook, so please let me know if there are any thoughts/concerns about the approach.
