### PR TITLE
fix: add analytics click trackers to article preview component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -209,9 +209,9 @@
       "dev": true
     },
     "@lonelyplanet/lp-analytics": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@lonelyplanet/lp-analytics/-/lp-analytics-2.2.2.tgz",
-      "integrity": "sha512-PY1vpM/Pq2CVUugDCPc7UIlrfPQipMscWPMHlSXlH1ZDNXEKAZlsZ4lC90FqzpC2TL/1KhMM37U7K8j8Ipo7uw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@lonelyplanet/lp-analytics/-/lp-analytics-2.2.3.tgz",
+      "integrity": "sha512-vt7fNcvyQeInUoJ9w1nSKpbP0snbbX93/Ckc7BlE6Nsp8Y5gzWC8O9l3TE2WxicIA40qONkmulsdJFmaX3sVrg==",
       "requires": {
         "@types/react": "^16.4.18",
         "@types/react-dom": "^16.0.9",
@@ -380,7 +380,7 @@
     "@storybook/mantra-core": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@storybook/mantra-core/-/mantra-core-1.7.2.tgz",
-      "integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
+      "integrity": "sha1-4Qx/rKKXaelxMeDgMI73z7ZVtww=",
       "dev": true,
       "requires": {
         "@storybook/react-komposer": "^2.0.1",
@@ -498,7 +498,7 @@
     "@storybook/react-stubber": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@storybook/react-stubber/-/react-stubber-1.0.1.tgz",
-      "integrity": "sha512-k+CHH+vA8bQfCmzBTtJsPkITFgD+C/w19KuByZ9WeEvNUFtnDaCqfP+Vp3/OR+3IAfAXYYOWolqPLxNPcEqEjw==",
+      "integrity": "sha1-jDEsJli57q/ORw4cOeQZPwtb+bE=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.5.0"
@@ -780,7 +780,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
@@ -2633,7 +2633,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
       "dev": true
     },
     "body-parser": {
@@ -2723,7 +2723,7 @@
     "brcast": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
-      "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
+      "integrity": "sha1-YlaoNJsg3p7tRCV6myTXFJPNSN0=",
       "dev": true
     },
     "brorand": {
@@ -2803,7 +2803,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -3135,7 +3135,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -3145,13 +3145,13 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+      "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3"
@@ -3347,7 +3347,7 @@
       "dependencies": {
         "color": {
           "version": "0.11.4",
-          "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+          "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
           "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
           "dev": true,
           "requires": {
@@ -3478,7 +3478,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
       "dev": true
     },
     "conventional-changelog": {
@@ -4053,7 +4053,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -4313,7 +4313,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -4416,7 +4416,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -5517,7 +5517,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -6053,7 +6053,7 @@
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc=",
       "dev": true
     },
     "fs-write-stream-atomic": {
@@ -6624,7 +6624,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "function.prototype.name": {
       "version": "1.1.0",
@@ -6998,7 +6998,7 @@
     "glamor": {
       "version": "2.20.40",
       "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
-      "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
+      "integrity": "sha1-9gZmA1e3zxjfrOcxrRos+pOBfwU=",
       "dev": true,
       "requires": {
         "fbjs": "^0.8.12",
@@ -7156,7 +7156,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -7736,7 +7736,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "inline-style-prefixer": {
@@ -7873,7 +7873,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-builtin-module": {
@@ -8055,7 +8055,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -8251,7 +8251,7 @@
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -8888,7 +8888,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -8898,7 +8898,7 @@
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY=",
       "dev": true
     },
     "mime-db": {
@@ -8952,7 +8952,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -9032,7 +9032,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -9243,7 +9243,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -9613,7 +9613,7 @@
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
       "dev": true,
       "requires": {
         "execa": "^0.7.0",
@@ -10028,7 +10028,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10101,7 +10101,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10173,7 +10173,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10244,7 +10244,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10315,7 +10315,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10386,7 +10386,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10457,7 +10457,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10529,7 +10529,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10704,7 +10704,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10775,7 +10775,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10860,7 +10860,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -10939,7 +10939,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11011,7 +11011,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11085,7 +11085,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11159,7 +11159,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11269,7 +11269,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11343,7 +11343,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11415,7 +11415,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11487,7 +11487,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11558,7 +11558,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11631,7 +11631,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11716,7 +11716,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11789,7 +11789,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11868,7 +11868,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
           "dev": true,
           "requires": {
             "chalk": "^1.1.3",
@@ -11948,7 +11948,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
       "dev": true
     },
     "process": {
@@ -11972,7 +11972,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -11986,7 +11986,7 @@
     "promise.prototype.finally": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
-      "integrity": "sha512-7p/K2f6dI+dM8yjRQEGrTQs5hTQixUAdOGpMEA3+pVxpX5oHKRSKAXyLw9Q9HUWDTdwtoo39dSHGQtN90HcEwQ==",
+      "integrity": "sha1-ZvFhsWQ2NuUOfPIB3BuEqFfzhk4=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -12146,7 +12146,7 @@
     "radium": {
       "version": "0.19.6",
       "resolved": "https://registry.npmjs.org/radium/-/radium-0.19.6.tgz",
-      "integrity": "sha512-IABYntqCwYelUUIwA52maSCgJbqtJjHKIoD21wgpw3dGhIUbJ5chDShDGdaFiEzdF03hN9jfQqlmn0bF4YhfrQ==",
+      "integrity": "sha1-uGch0I29MDsGGkri67BsxuM1rnI=",
       "requires": {
         "array-find": "^1.0.0",
         "exenv": "^1.2.1",
@@ -12545,7 +12545,7 @@
     "react-icons": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-2.2.7.tgz",
-      "integrity": "sha512-0n4lcGqzJFcIQLoQytLdJCE0DKSA9dkwEZRYoGrIDJZFvIT6Hbajx5mv9geqhqFiNjUgtxg8kPyDfjlhymbGFg==",
+      "integrity": "sha1-14YIJrJYVXUQ2sEGgKvqXKI89lA=",
       "dev": true,
       "requires": {
         "react-icon-base": "2.1.0"
@@ -12576,7 +12576,7 @@
     "react-markdown-renderer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/react-markdown-renderer/-/react-markdown-renderer-1.4.0.tgz",
-      "integrity": "sha512-+8ZI5EmbSuKfq3RK7KlJwxgtH7epzaG8hPktvAhDkXtbjiX9t+4sznedXX5G/EEOQJoZsl2/UfnTRMeUfojDRg==",
+      "integrity": "sha1-87lb2fx/e/irPwFQqmlrQXQOfQE=",
       "requires": {
         "prop-types": "^15.5.10",
         "remarkable": "^1.7.1"
@@ -12665,7 +12665,7 @@
     "react-photoswipe": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-photoswipe/-/react-photoswipe-1.3.0.tgz",
-      "integrity": "sha512-1ok6vXFAj/rd60KIzF0YwCdq1Tcl+8yKqWJHbPo43lJBuwUi+LBosmBdJmswpiOzMn2496ekU0k/r6aHWQk7PQ==",
+      "integrity": "sha1-AW3ZeEUKhAZ3bbl1Eer5by/7nPs=",
       "requires": {
         "classnames": "^2.2.3",
         "lodash.pick": "^4.2.1",
@@ -12676,7 +12676,7 @@
     "react-portal": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-3.2.0.tgz",
-      "integrity": "sha512-avb1FreAZAVCvNNyS2dCpxZiPYPJnAasHYPxdVBTROgNFeI+KSb+OoMHNsC1GbDawESCriPwCX+qKua6WSPIFw==",
+      "integrity": "sha1-QiThmysF1cvnMKe6DjTsdYXeAEM=",
       "requires": {
         "prop-types": "^15.5.8"
       }
@@ -12800,7 +12800,7 @@
     "react-textarea-autosize": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz",
-      "integrity": "sha512-bx6z2I35aapr71ggw2yZIA4qhmqeTa4ZVsSaTeFvtf9kfcZppDBh2PbMt8lvbdmzEk7qbSFhAxR9vxEVm6oiMg==",
+      "integrity": "sha1-K3j5BnGA9BsIrFn3jxWBq63WHlQ=",
       "dev": true,
       "requires": {
         "prop-types": "^15.6.0"
@@ -12821,7 +12821,7 @@
     "react-treebeard": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-treebeard/-/react-treebeard-2.1.0.tgz",
-      "integrity": "sha512-unoy8IJL1NR5jgTtK+CqOCZKZylh/Tlid0oYajW9bLZCbFelxzmCsF8Y2hyS6pvHqM4W501oOm5O/jvg3VZCrg==",
+      "integrity": "sha1-+9XPUQibbwmpsYNQqzvd9zbleAA=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.23.0",
@@ -12846,7 +12846,7 @@
     "react-validate-form": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/react-validate-form/-/react-validate-form-1.0.6.tgz",
-      "integrity": "sha512-JitYs9Z0LDsE0BLk4Z1vzg6M70NVECOOndndxA/i/NGr0bc5wNQfSAa1M5Grlk5A0/1eNRg+cEp4z/IJ23MDsQ==",
+      "integrity": "sha1-GhzCeOTHdKMcMZlhxVuiUjsCmqs=",
       "requires": {
         "lodash": "^4.17.4",
         "rimraf": "^2.6.0"
@@ -12864,7 +12864,7 @@
     "reactcss": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "integrity": "sha1-wAATh15Vexzw39mjaKHD2rO1SN0=",
       "dev": true,
       "requires": {
         "lodash": "^4.0.1"
@@ -13026,7 +13026,7 @@
     "redux": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "integrity": "sha1-BrcxIyFZAdJdBlvjQusCa8HIU3s=",
       "dev": true,
       "requires": {
         "lodash": "^4.2.1",
@@ -13054,7 +13054,7 @@
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.18.0",
@@ -13065,7 +13065,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -13374,7 +13374,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "scheduler": {
@@ -13511,7 +13511,7 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
       "dev": true
     },
     "sha.js": {
@@ -13608,7 +13608,7 @@
     "slick-carousel": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
-      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA=="
+      "integrity": "sha1-pL+ykBSIe7Zs5Si5C9DNomLMj40="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -13750,7 +13750,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "source-map-resolve": {
@@ -13769,7 +13769,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
@@ -13834,7 +13834,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
         "through": "2"
@@ -13852,7 +13852,7 @@
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
       "dev": true,
       "requires": {
         "through2": "^2.0.2"
@@ -14340,7 +14340,7 @@
     "tiny-emitter": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
-      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
+      "integrity": "sha1-gtJ0aKylrejl/R5tIrV91D69+3w="
     },
     "tinycolor2": {
       "version": "1.4.1",
@@ -14723,7 +14723,7 @@
     "url-loader": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
-      "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
+      "integrity": "sha1-oAenEJYg6dmI0UvOZ3od7Lmpk/c=",
       "dev": true,
       "requires": {
         "loader-utils": "^1.0.2",
@@ -14977,7 +14977,7 @@
     "webpack-dev-middleware": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+      "integrity": "sha1-+PwRIM47T8VoDO7LQ9d3lmshEF4=",
       "dev": true,
       "requires": {
         "memory-fs": "~0.4.1",
@@ -14990,7 +14990,7 @@
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/lonelyplanet/backpack-ui.git"
   },
   "dependencies": {
-    "@lonelyplanet/lp-analytics": "^2.0.8",
+    "@lonelyplanet/lp-analytics": "^2.2.3",
     "axios": "^0.15.3",
     "babel-plugin-transform-runtime": "^6.23.0",
     "chai": "^3.5.0",

--- a/src/components/articlePreview/index.jsx
+++ b/src/components/articlePreview/index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import assign from "object-assign";
 
+import { analytics, EventNames, AnalyticsEvent } from "@lonelyplanet/lp-analytics";
 import colors from "../../styles/colors";
 import font from "../../utils/font";
 import CategoryLabelLink from "../categoryLabelLink";
@@ -9,7 +10,17 @@ import Heading from "../heading";
 
 const markup = html => ({ __html: html });
 
-function ArticlePreview({ title, paragraph, image, imageAlt, href, category, categoryHref }) {
+function ArticlePreview({
+  title,
+  paragraph,
+  image,
+  imageAlt,
+  href,
+  category,
+  categoryHref,
+  trackEventName,
+  trackEventPosition,
+}) {
   const styles = {
     container: {
       fontFamily: font("benton"),
@@ -52,30 +63,72 @@ function ArticlePreview({ title, paragraph, image, imageAlt, href, category, cat
   };
 
   return (
-    <article className="ArticlePreview" style={styles.container}>
-      <figure className="ArticlePreview-image" style={styles.imageContainer}>
-        <a href={href} style={styles.anchor}>
-          <img src={image} alt={imageAlt} style={styles.image} />
-        </a>
-      </figure>
+    <AnalyticsEvent
+      render={({ track }) => (
+        <article className="ArticlePreview" style={styles.container}>
+          <figure className="ArticlePreview-image" style={styles.imageContainer}>
+            <a
+              href={href}
+              style={styles.anchor}
+              onClick={() => {
+                track({
+                  [analytics.eventName]: EventNames.promotionClick,
+                  ecommerce: {
+                    promoClick: {
+                      promotions: [
+                        {
+                          name: trackEventName,
+                          creative: "article preview image",
+                          position: trackEventPosition,
+                        },
+                      ],
+                    },
+                  },
+                });
+              }}
+            >
+              <img src={image} alt={imageAlt} style={styles.image} />
+            </a>
+          </figure>
 
-      <div className="ArticlePreview-text" style={styles.textContainer}>
-        <CategoryLabelLink href={categoryHref}>{category}</CategoryLabelLink>
-        <a href={href} style={assign({}, styles.anchor, { marginTop: "12px" })}>
-          <Heading
-            weight="thick"
-            override={styles.heading}
-          >
-            {title}
-          </Heading>
+          <div className="ArticlePreview-text" style={styles.textContainer}>
+            <CategoryLabelLink href={categoryHref}>{category}</CategoryLabelLink>
+            <a
+              href={href}
+              style={assign({}, styles.anchor, { marginTop: "12px" })}
+              onClick={() => {
+                track({
+                  [analytics.eventName]: EventNames.promotionClick,
+                  ecommerce: {
+                    promoClick: {
+                      promotions: [
+                        {
+                          name: trackEventName,
+                          creative: "article preview text",
+                          position: trackEventPosition,
+                        },
+                      ],
+                    },
+                  },
+                });
+              }}
+            >
+              <Heading
+                weight="thick"
+                override={styles.heading}
+              >
+                {title}
+              </Heading>
 
-          <p
-            style={styles.paragraph}
-            dangerouslySetInnerHTML={markup(paragraph)}
-          />
-        </a>
-      </div>
-    </article>
+              <p
+                style={styles.paragraph}
+                dangerouslySetInnerHTML={markup(paragraph)}
+              />
+            </a>
+          </div>
+        </article>
+      )}
+    />
   );
 }
 
@@ -87,10 +140,14 @@ ArticlePreview.propTypes = {
   href: PropTypes.string.isRequired,
   category: PropTypes.string.isRequired,
   categoryHref: PropTypes.string.isRequired,
+  trackEventName: PropTypes.string,
+  trackEventPosition: PropTypes.string,
 };
 
 ArticlePreview.defaultProps = {
   imageAlt: "",
+  trackEventName: "article preview click",
+  trackEventPosition: "article preview",
 };
 
 export default ArticlePreview;

--- a/src/components/articlePreview/index.jsx
+++ b/src/components/articlePreview/index.jsx
@@ -18,6 +18,7 @@ function ArticlePreview({
   href,
   category,
   categoryHref,
+  trackEventId,
   trackEventName,
   trackEventPosition,
 }) {
@@ -77,6 +78,7 @@ function ArticlePreview({
                     promoClick: {
                       promotions: [
                         {
+                          id: trackEventId,
                           name: trackEventName,
                           creative: "article preview image",
                           position: trackEventPosition,
@@ -103,6 +105,7 @@ function ArticlePreview({
                     promoClick: {
                       promotions: [
                         {
+                          id: trackEventId,
                           name: trackEventName,
                           creative: "article preview text",
                           position: trackEventPosition,
@@ -140,12 +143,14 @@ ArticlePreview.propTypes = {
   href: PropTypes.string.isRequired,
   category: PropTypes.string.isRequired,
   categoryHref: PropTypes.string.isRequired,
+  trackEventId: PropTypes.string,
   trackEventName: PropTypes.string,
   trackEventPosition: PropTypes.string,
 };
 
 ArticlePreview.defaultProps = {
   imageAlt: "",
+  trackEventId: "article preview - 1",
   trackEventName: "article preview click",
   trackEventPosition: "article preview",
 };

--- a/src/components/articlePreview/index.jsx
+++ b/src/components/articlePreview/index.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import assign from "object-assign";
 
-import { analytics, EventNames, AnalyticsEvent } from "@lonelyplanet/lp-analytics";
+import { AnalyticsEvent, createPromotionClickEvent } from "@lonelyplanet/lp-analytics";
 import colors from "../../styles/colors";
 import font from "../../utils/font";
 import CategoryLabelLink from "../categoryLabelLink";
@@ -72,21 +72,14 @@ function ArticlePreview({
               href={href}
               style={styles.anchor}
               onClick={() => {
-                track({
-                  [analytics.eventName]: EventNames.promotionClick,
-                  ecommerce: {
-                    promoClick: {
-                      promotions: [
-                        {
-                          id: trackEventId,
-                          name: trackEventName,
-                          creative: "article preview image",
-                          position: trackEventPosition,
-                        },
-                      ],
-                    },
-                  },
-                });
+                track(
+                  createPromotionClickEvent({
+                    id: trackEventId,
+                    name: trackEventName,
+                    creative: "article preview image",
+                    position: trackEventPosition,
+                  }),
+                );
               }}
             >
               <img src={image} alt={imageAlt} style={styles.image} />
@@ -99,21 +92,14 @@ function ArticlePreview({
               href={href}
               style={assign({}, styles.anchor, { marginTop: "12px" })}
               onClick={() => {
-                track({
-                  [analytics.eventName]: EventNames.promotionClick,
-                  ecommerce: {
-                    promoClick: {
-                      promotions: [
-                        {
-                          id: trackEventId,
-                          name: trackEventName,
-                          creative: "article preview text",
-                          position: trackEventPosition,
-                        },
-                      ],
-                    },
-                  },
-                });
+                track(
+                  createPromotionClickEvent({
+                    id: trackEventId,
+                    name: trackEventName,
+                    creative: "article preview text",
+                    position: trackEventPosition,
+                  }),
+                );
               }}
             >
               <Heading
@@ -150,7 +136,7 @@ ArticlePreview.propTypes = {
 
 ArticlePreview.defaultProps = {
   imageAlt: "",
-  trackEventId: "article preview - 1",
+  trackEventId: "article preview",
   trackEventName: "article preview click",
   trackEventPosition: "article preview",
 };

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -1410,6 +1410,9 @@ storiesOf("Lockups", module)
       href={text("URL", "/")}
       category={text("Category name", "Art and culture")}
       categoryHref={text("Category URL", "/")}
+      trackEventId={text("Tracking event id")}
+      trackEventName={text("Tracking event name")}
+      trackEventPosition={text("Tracking event position")}
     />
   ))
   .add("Bookmark list header", () => (


### PR DESCRIPTION
Adding click event tracker for the article preview component. By adding this, in each repo that this component is being used, we can add a name and id to the event tracker so that these are viewable in GA. Per Kristen and Analytics Pros, we should use "Promotion Click" for this type of even tracking.

@johnwquarles can you please confirm that this is working as it should? I was using that chrome extension but it appears that it doesn't work on localhost, or perhaps I am missing something. Can you please let me know the best way to test this?