### PR TITLE
feat: add custom data attributes for automation purposes

### DIFF
--- a/spec/utils/createQAHook.spec.js
+++ b/spec/utils/createQAHook.spec.js
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import createQAHook from "../../src/utils/createQAHook";
+
+describe('createQAHook', () => {
+    describe('hook present', () => {
+        it("should create hooks properly with leading/trailing whitespace", () => {
+            expect(createQAHook("       tEst HOOK        ")).to.equal("test-hook-unknown");
+        });
+    
+        it("should create hooks properly with multiple whitespaces in between text", () => {
+            expect(createQAHook("TEST         HOOK   ")).to.equal("test---------hook-unknown");
+        });
+    
+        it("should create hooks properly with numbers", () => {
+            expect(createQAHook(12345)).to.equal("12345-unknown")
+        })
+    
+        it("should create hook called default if wrong type inserted into function (object)", () => {
+            expect(createQAHook({ nottheright:'type' })).to.equal("default-unknown");
+        });
+    
+        it("should create hook called default if wrong type inserted into function (func)", () => {
+            expect(createQAHook(() => {})).to.equal("default-unknown");
+        });
+    
+        it("should create hook called default if wrong type inserted into function (array object)", () => {
+            expect(createQAHook([])).to.equal("default-unknown");
+        });
+    
+        it("should create hooks properly with leading/trailing whitespace", () => {
+            expect(createQAHook(null, "       tEst HOOK        ")).to.equal("test-hook-unknown");
+        });
+    })
+
+
+    describe('fallback present', () => {
+        it("should create hooks properly with leading/trailing whitespace", () => {
+            expect(createQAHook(null, "       tEst HOOK        ")).to.equal("test-hook-unknown");
+        });
+    
+        it("should create hooks properly with multiple whitespaces in between text", () => {
+            expect(createQAHook(null, "TEST         HOOK   ")).to.equal("test---------hook-unknown");
+        });
+    
+        it("should create hooks properly with numbers", () => {
+            expect(createQAHook(null, 12345)).to.equal("12345-unknown")
+        })
+    
+        it("should create hook called default-object if wrong type inserted into function (object)", () => {
+            expect(createQAHook(null, { nottheright:'type' })).to.equal("default-unknown");
+        });
+    
+        it("should create hook called default-function if wrong type inserted into function (func)", () => {
+            expect(createQAHook(null, () => {})).to.equal("default-unknown");
+        });
+    
+        it("should create hook called default-object if wrong type inserted into function (array object)", () => {
+            expect(createQAHook(null, [])).to.equal("default-unknown");
+        });
+    
+        it("should create hooks properly with leading/trailing whitespace", () => {
+            expect(createQAHook(null, "       tEst HOOK        ")).to.equal("test-hook-unknown");
+        });
+    })
+
+    describe('type present', () => {
+        it("should create hooks properly with leading/trailing whitespace", () => {
+            expect(createQAHook(null, "       tEst HOOK        ", "btn")).to.equal("test-hook-btn");
+        });
+    
+        it("should create hooks properly with multiple whitespaces in between text", () => {
+            expect(createQAHook(null, "TEST         HOOK   ", "link")).to.equal("test---------hook-link");
+        });
+    
+        it("should create hooks properly with numbers", () => {
+            expect(createQAHook(null, 12345, "button")).to.equal("12345-button")
+        })
+    
+        it("should create hook called default if wrong type inserted into function (object)", () => {
+            expect(createQAHook(null, { nottheright:'type' }, "       type       ")).to.equal("default-type");
+        });
+    
+        it("should create hook called default if wrong type inserted into function (func)", () => {
+            expect(createQAHook(null, () => {}, "anything")).to.equal("default-anything");
+        });
+    
+        it("should create hook called default if wrong type inserted into function (array object)", () => {
+            expect(createQAHook(null, [], "yolo")).to.equal("default-yolo");
+        });
+    
+        it("should create hooks properly with leading/trailing whitespace", () => {
+            expect(createQAHook(null, "       tEst HOOK        ", "nAv")).to.equal("test-hook-nav");
+        });
+    })
+
+    describe('everything present', () => {
+        it('should work properly', () => {
+            expect(createQAHook("qa", "hook", "data")).to.equal("qa-data");
+        })
+    })
+
+    describe('nothing present', () => {
+        it('should work properly', () => {
+            expect(createQAHook(null, null, null)).to.equal("default-default");
+        })
+    })
+
+    describe('type only present', () => {
+        it('should work properly', () => {
+            expect(createQAHook(null, null, '         type of        ')).to.equal("default-type-of");
+        })
+    });
+});

--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -8,6 +8,7 @@ import timing from "../../styles/timing";
 import { lighten } from "../../utils/color";
 import { outline } from "../../utils/mixins";
 import propTypes from "../../utils/propTypes";
+import createQAHook from "../../utils/createQAHook";
 
 const hoverStyles = {
   base: {
@@ -213,6 +214,7 @@ function Button({
   disabled,
   customStyles,
   className,
+  qaHook,
   ...rest
 }) {
   const Element = href ? "a" : "button";
@@ -238,6 +240,7 @@ function Button({
       className={cn("Button", className)}
       style={style}
       href={href}
+      data-qa={createQAHook(qaHook, cn("Button", className), "btn")}
       onClick={onClick}
       role={role}
       disabled={disabled}
@@ -320,6 +323,11 @@ Button.propTypes = {
    * Add classname to button
    */
   className: PropTypes.string,
+
+  /**
+   * Add qa-hook to button
+   */
+  qaHook: PropTypes.string,
 };
 
 Button.defaultProps = {
@@ -334,6 +342,7 @@ Button.defaultProps = {
   disabled: false,
   customStyles: null,
   className: null,
+  qaHook: null,
 };
 
 Button.styles = styles;

--- a/src/components/navigation/navigation.jsx
+++ b/src/components/navigation/navigation.jsx
@@ -5,6 +5,7 @@ import Container from "../container";
 import colors from "../../styles/colors";
 import zIndex from "../../styles/zIndex";
 import propTypes from "../../utils/propTypes";
+import createQAHook from "../../utils/createQAHook";
 
 const styles = {
   nav: {
@@ -28,11 +29,12 @@ const styles = {
 };
 
 const Navigation = (props) => {
-  const { children, height, sticky, style, ...properties } = props;
+  const { children, qaHook, height, sticky, style, ...properties } = props;
 
   return (
     <nav
       className="Navigation"
+      data-qa={createQAHook(qaHook, "Navigation", "nav")}
       style={[
         styles.nav,
         sticky && { position: "sticky", top: 0 },
@@ -66,10 +68,12 @@ Navigation.propTypes = {
   height: PropTypes.number,
   sticky: PropTypes.bool,
   style: propTypes.style,
+  qaHook: PropTypes.string,
 };
 
 Navigation.defaultProps = {
   height: 80,
+  qaHook: null,
 };
 
 export default radium(Navigation);

--- a/src/components/navigation/navigationTab.jsx
+++ b/src/components/navigation/navigationTab.jsx
@@ -8,6 +8,7 @@ import { fontWeightMedium } from "../../styles/typography";
 import propTypes from "../../utils/propTypes";
 import { outline } from "../../utils/mixins";
 import { textUppercase } from "../../utils/typography";
+import createQAHook from "../../utils/createQAHook";
 
 const styles = Object.assign({}, {
   backgroundColor: colors.bgPrimary,
@@ -39,12 +40,13 @@ const styles = Object.assign({}, {
 }, textUppercase());
 
 const NavigationTab = (props) => {
-  const { children, onClick, active, style, ...properties } = props;
+  const { children, qaHook, onClick, active, style, ...properties } = props;
 
   return (
     <button
       className="NavigationTab"
       onClick={onClick}
+      data-qa={createQAHook(qaHook, "NavigationTab", "btn")}
       style={[
         styles,
         active && { borderBottomColor: colors.linkPrimary },
@@ -62,6 +64,11 @@ NavigationTab.propTypes = {
   onClick: PropTypes.func,
   active: PropTypes.bool,
   style: propTypes.style,
+  qaHook: PropTypes.string,
+};
+
+NavigationTab.defaultProps = {
+  qaHook: null,
 };
 
 export default radium(NavigationTab);

--- a/src/utils/createQAHook.js
+++ b/src/utils/createQAHook.js
@@ -1,0 +1,13 @@
+const uniformString = (string) => `${string.toString().toLowerCase().trim().replace(/ /gi, "-")}`;
+
+const sanitize = (el) =>
+    (typeof el === "string" || typeof el === "number"
+        ? uniformString(el)
+        : "default");
+
+const createQAHook = (hook, fallback = "fallback", type = "unknown") => (hook
+    ? `${sanitize(hook)}-${sanitize(type)}`
+    : `${sanitize(fallback)}-${sanitize(type)}`);
+
+
+export default createQAHook;

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -345,6 +345,7 @@ storiesOf("Buttons", module)
         full={boolean("Full width", false)}
         rounded={boolean("Rounded", false)}
         onClick={action("clicked")}
+        qaHook={text("qaHook", "QA hook")}
       >
         {text("Text", "Hello Button")}
       </Button>
@@ -360,6 +361,7 @@ storiesOf("Buttons", module)
         full={boolean("Full width", false)}
         rounded={boolean("Rounded", false)}
         onClick={action("clicked")}
+        qaHook={text("qaHook", "QA hook")}
       >
         {text("Text", "Hello Button")}
       </Button>
@@ -1917,14 +1919,14 @@ storiesOf("Navigation", module)
   .addDecorator(withKnobs)
   .add("Navigation", () => (
     <Navigation height={number("Height", 80)} sticky={boolean("Sticky", false)}>
-      <NavigationTab active={boolean("Active", true)} onClick={action("Experiences tab clicked")}>
+      <NavigationTab qaHook={text("qaHook", "Experiences")} active={boolean("Active", true)} onClick={action("Experiences tab clicked")}>
         {text("Text", "Experiences")}
       </NavigationTab>
-      <NavigationTab onClick={action("Map tab clicked")}>Map</NavigationTab>
-      <NavigationTab onClick={action("Articles tab clicked")}>Articles</NavigationTab>
-      <NavigationTab onClick={action("Interests tab clicked")}>Interests</NavigationTab>
-      <NavigationTab onClick={action("Books tab clicked")}>Books</NavigationTab>
-      <NavigationTab onClick={action("Adventures tab clicked")}>Adventures</NavigationTab>
+      <NavigationTab qaHook={text("qaHook", "Map")} onClick={action("Map tab clicked")}>Map</NavigationTab>
+      <NavigationTab qaHook={text("qaHook", "Articles")} onClick={action("Articles tab clicked")}>Articles</NavigationTab>
+      <NavigationTab qaHook={text("qaHook", "Interests")} onClick={action("Interests tab clicked")}>Interests</NavigationTab>
+      <NavigationTab qaHook={text("qaHook", "Books")} onClick={action("Books tab clicked")}>Books</NavigationTab>
+      <NavigationTab qaHook={text("qaHook", "Adventures")} onClick={action("Adventures tab clicked")}>Adventures</NavigationTab>
     </Navigation>
   ))
   .add("Sectional nav", () => (
@@ -2045,6 +2047,7 @@ storiesOf("Popovers", module)
             border
             color="gray"
             size="small"
+            qaHook="qa hook"
             customStyles={{
               alignItems: "center",
               display: "inline-flex",
@@ -2094,6 +2097,7 @@ storiesOf("Popovers", module)
               actions={[
                 <Button
                   size="small"
+                  qaHook="qa hook"
                   onClick={action("✌🏼")}
                   rounded
                 >
@@ -2101,6 +2105,7 @@ storiesOf("Popovers", module)
                 </Button>,
                 <Button
                   size="small"
+                  qaHook="qa hook"
                   onClick={toggle}
                   color="gray"
                   rounded
@@ -3156,26 +3161,26 @@ storiesOf("Widgets", module)
         <MultiStep currentStep={currentStep}>
           <div>
             <h1>Step {currentStep}</h1>
-            <Button size="tiny" onClick={goToNextStep}>Next step</Button>
-            <Button size="tiny" onClick={() => { setCurrentStep(4); }}>Jump to step 4</Button>
+            <Button qaHook="qa hook" size="tiny" onClick={goToNextStep}>Next step</Button>
+            <Button qaHook="qa hook" size="tiny" onClick={() => { setCurrentStep(4); }}>Jump to step 4</Button>
           </div>
 
           <div>
             <h1>Step {currentStep}</h1>
-            <Button size="tiny" onClick={goToPreviousStep}>Previous step</Button>
-            <Button size="tiny" onClick={goToNextStep}>Next step</Button>
+            <Button qaHook="qa hook" size="tiny" onClick={goToPreviousStep}>Previous step</Button>
+            <Button qaHook="qa hook" size="tiny" onClick={goToNextStep}>Next step</Button>
           </div>
 
           <div>
             <h1>Step {currentStep}</h1>
-            <Button size="tiny" onClick={goToPreviousStep}>Previous step</Button>
-            <Button size="tiny" onClick={goToNextStep}>Next step</Button>
+            <Button qaHook="qa hook" size="tiny" onClick={goToPreviousStep}>Previous step</Button>
+            <Button qaHook="qa hook" size="tiny" onClick={goToNextStep}>Next step</Button>
           </div>
 
           <div>
             <h1>Step {currentStep}</h1>
-            <Button size="tiny" onClick={goToPreviousStep}>Previous step</Button>
-            <Button size="tiny" onClick={() => { setCurrentStep(1); }}>Jump to step 1</Button>
+            <Button qaHook="qa hook" size="tiny" onClick={goToPreviousStep}>Previous step</Button>
+            <Button qaHook="qa hook" size="tiny" onClick={() => { setCurrentStep(1); }}>Jump to step 1</Button>
           </div>
         </MultiStep>
       )}


### PR DESCRIPTION
Allowing our automation to become less brittle to updating changing classes/ids. These custom data attributes will be available for QA Engineers to update for automation (integration/E2E) and empower the FE developers to change classes/ids without concern.

See: https://blog.kentcdodds.com/making-your-ui-tests-resilient-to-change-d37a6ee37269

This may not be the last PR regarding data hooks but I wanted to get the pattern passed before peppering it where it makes the most sense (most actionable elements [click, link, nav, et. al]) For this PR, just button and nav were touched. 