### PR TITLE
fix: update prev/next button on tallCarousel

### DIFF
--- a/src/components/tallCarousel/index.jsx
+++ b/src/components/tallCarousel/index.jsx
@@ -75,6 +75,12 @@ const styles = {
       },
       ".PaginatorButton": {
         zIndex: zIndex.top,
+        color: colors.bgDark,
+      },
+      ".PaginatorButton svg": {
+        position: "relative",
+        left: "-10px",
+        top: "-5px",
       },
       ".slick-slide:hover": {
         zIndex: zIndex.top - 1,


### PR DESCRIPTION
Fixes issue where react-slick classes are overriding our custom arrows for the TallCarousel.