### PR TITLE
fix: compile motion ui pack library folder

### DIFF
--- a/src/components/tooltip/index.jsx
+++ b/src/components/tooltip/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { spring } from "react-motion";
-import Transition from "../../../libs/react-motion-ui-pack/Transition";
+import Transition from "../../libs/react-motion-ui-pack/Transition";
 import Flyout from "../flyout";
 import motionPresets from "../../utils/motionPresets";
 

--- a/src/libs/react-motion-ui-pack/Transition.jsx
+++ b/src/libs/react-motion-ui-pack/Transition.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // https://github.com/souporserious/react-motion-ui-pack/blob/master/src/Transition.jsx
 import React, { Component, Children, createElement, cloneElement } from 'react'
 import PropTypes from 'prop-types'

--- a/src/libs/react-motion-ui-pack/config-to-style.js
+++ b/src/libs/react-motion-ui-pack/config-to-style.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // https://github.com/souporserious/react-motion-ui-pack/blob/master/src/config-to-style.js
 const TRANSFORM = require('./get-prefix')('transform')
 const UNIT_TRANSFORMS = ['translateX', 'translateY', 'translateZ', 'transformPerspective']

--- a/src/libs/react-motion-ui-pack/from-RM-styles.js
+++ b/src/libs/react-motion-ui-pack/from-RM-styles.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // https://github.com/souporserious/react-motion-ui-pack/blob/master/src/from-RM-styles.js
 export default function fromRMStyles(config) {
   const values = {}

--- a/src/libs/react-motion-ui-pack/get-prefix.js
+++ b/src/libs/react-motion-ui-pack/get-prefix.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // https://github.com/souporserious/get-prefix/blob/1.0.0/lib/index.js
 'use strict';
 

--- a/src/libs/react-motion-ui-pack/is-element.js
+++ b/src/libs/react-motion-ui-pack/is-element.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // https://github.com/souporserious/react-motion-ui-pack/blob/master/src/is-element.js
 import { isValidElement } from 'react'
 

--- a/src/libs/react-motion-ui-pack/special-assign.js
+++ b/src/libs/react-motion-ui-pack/special-assign.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // https://github.com/souporserious/react-motion-ui-pack/blob/master/src/special-assign.js
 export default function specialAssign(a, b, reserved) {
   for (var x in b) {

--- a/src/libs/react-motion-ui-pack/to-RM-styles.js
+++ b/src/libs/react-motion-ui-pack/to-RM-styles.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // https://github.com/souporserious/react-motion-ui-pack/blob/master/src/to-RM-styles.js
 import { spring } from 'react-motion'
 


### PR DESCRIPTION
This folder needs to be nested in src so that it also gets compiled by
Babel when it hits the dist folder, otherwise it can't always be
imported.