### PR TITLE
fix: add additional qa hook functionality

### DIFF
--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -1,22 +1,22 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link as RouterLink } from "react-router";
+import createQAHook from "../../utils/createQAHook";
 
 const isExternal = (url) => /^(http|https):\/\//.test(url || "");
 
-const Link = (props) => (
-  isExternal(props.to) || (!props.to && props.onClick) ?
+const Link = ({ to, onClick, children, qaHook }) => (
+  isExternal(to) || (!to && onClick) ?
     <a
-      href={props.to}
-      data-qa={props.qaHook ? "external-link" : null}
-      onClick={props.onClick}
-      {...props}
+      href={to}
+      data-qa={qaHook ? createQAHook(`${qaHook}`, "external-link", "link") : null}
+      onClick={onClick}
     >
-      {props.children}
+      {children}
     </a>
     :
-    <RouterLink {...props}>
-      {props.children}
+    <RouterLink to={to} onClick={onClick} data-qa={qaHook}>
+      {children}
     </RouterLink>
 );
 
@@ -28,11 +28,11 @@ Link.propTypes = {
     PropTypes.node,
     PropTypes.element,
   ]),
-  qaHook: PropTypes.bool,
+  qaHook: PropTypes.string,
 };
 
 Link.defaultProps = {
-  qaHook: false,
+  qaHook: null,
 };
 
 export default Link;

--- a/src/components/segment/index.jsx
+++ b/src/components/segment/index.jsx
@@ -52,10 +52,12 @@ const Segment = ({
   showAbove,
   children,
   style,
+  qaHook,
 }) => (
   <div
     className="Segmented"
     id={id}
+    data-qa={qaHook}
     style={[
       styles.container.default,
       border && styles.container.hasBorder,
@@ -85,6 +87,11 @@ Segment.propTypes = {
     PropTypes.element,
     PropTypes.arrayOf(PropTypes.element),
   ]),
+  qaHook: PropTypes.string,
+};
+
+Segment.defaultProps = {
+  qaHook: null,
 };
 
 export default radium(Segment);

--- a/src/components/thumbnailListItem/index.jsx
+++ b/src/components/thumbnailListItem/index.jsx
@@ -189,6 +189,7 @@ const ThumbnailListItem = ({
   lineClamp,
   theme,
   style,
+  qaHook,
 }) => (
   <div
     className={cn("ListItem-thumbnail", theme && `ListItem-thumbnail--${theme}`)}
@@ -215,6 +216,7 @@ const ThumbnailListItem = ({
         to={href}
         onClick={onClick}
         style={styles.imageAnchor}
+        qaHook={qaHook}
       >
         <CoverPhoto
           src={imagePath}
@@ -246,6 +248,7 @@ const ThumbnailListItem = ({
           to={href}
           onClick={onClick}
           style={styles.textAnchor}
+          qaHook={qaHook}
         >
           {status &&
             <div
@@ -309,11 +312,13 @@ ThumbnailListItem.propTypes = {
   lineClamp: PropTypes.number,
   theme: PropTypes.oneOf(["light", "dark", "active"]),
   style: propTypes.style,
+  qaHook: PropTypes.bool,
 };
 
 ThumbnailListItem.defaultProps = {
   theme: "light",
   lineClamp: 1,
+  qaHook: false,
 };
 
 export default radium(ThumbnailListItem);

--- a/src/components/video/videoPlaylist.jsx
+++ b/src/components/video/videoPlaylist.jsx
@@ -338,6 +338,7 @@ class VideoPlaylist extends Component {
       showFeaturedVideoCover,
       mobile,
       style,
+      qaHook,
     } = this.props;
 
     const { autoplay, childStyles } = this.state;
@@ -455,6 +456,7 @@ class VideoPlaylist extends Component {
                             styles.thumbnailListItem,
                             childStyles[v.id],
                           ]}
+                          qaHook={qaHook}
                         />
                       </div>
                     ))}
@@ -499,6 +501,7 @@ VideoPlaylist.propTypes = {
   onLoadVideo: PropTypes.func,
   mobile: PropTypes.bool,
   style: propTypes.style,
+  qaHook: PropTypes.bool,
 };
 
 VideoPlaylist.defaultProps = {
@@ -508,6 +511,7 @@ VideoPlaylist.defaultProps = {
   hideList: false,
   videoPopout: {},
   videoEmbed: {},
+  qaHook: false,
 };
 
 export default radium(VideoPlaylist);

--- a/src/components/video/videoPlaylistWithSlider.jsx
+++ b/src/components/video/videoPlaylistWithSlider.jsx
@@ -121,6 +121,7 @@ class VideoPlaylistWithSlider extends React.Component {
       showFeaturedVideoCover,
       followVideoUrls,
       style,
+      qaHook,
     } = this.props;
 
     const { video, autoplay, enableVideoInfo } = this.state;
@@ -150,6 +151,7 @@ class VideoPlaylistWithSlider extends React.Component {
                     ...(videoEmbed.vjsLP || {}),
                   },
                 }}
+                qaHook={qaHook}
               />
             </Container>
 
@@ -202,6 +204,7 @@ class VideoPlaylistWithSlider extends React.Component {
                           imagePath={v.thumbnailImage}
                           subtitle={[duration(v.duration)]}
                           lineClamp={0}
+                          qaHook={qaHook}
                         />
                       ))}
                     </ThumbnailList>
@@ -257,6 +260,7 @@ VideoPlaylistWithSlider.propTypes = {
   showFeaturedVideoCover: PropTypes.bool.isRequired,
   followVideoUrls: PropTypes.bool,
   style: propTypes.style,
+  qaHook: PropTypes.bool,
 };
 
 VideoPlaylistWithSlider.defaultProps = {
@@ -266,6 +270,7 @@ VideoPlaylistWithSlider.defaultProps = {
   showFeaturedVideoCover: false,
   videoPopout: {},
   videoEmbed: {},
+  qaHook: false,
 };
 
 export default radium(VideoPlaylistWithSlider);

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -2498,16 +2498,19 @@ storiesOf("Video components", module)
           title="List item 1"
           theme="light"
           imagePath="https://lonelyplanetstatic.imgix.net/op-video-sync/images/production/p-5615400608001-brightcove-lonely-planets-best-destinations-to-visit-in-2018-20171028-052139.jpg?sharp=10&q=50&w=160&h=90"
+          qaHook={false}
         />
         <ThumbnailListItem
           title="List item 2"
           theme="light"
           imagePath="https://lonelyplanetstatic.imgix.net/op-video-sync/images/production/p-5615400608001-brightcove-lonely-planets-best-destinations-to-visit-in-2018-20171028-052139.jpg?sharp=10&q=50&w=160&h=90"
+          qaHook={false}
         />
         <ThumbnailListItem
           title="List item 3"
           theme="light"
           imagePath="https://lonelyplanetstatic.imgix.net/op-video-sync/images/production/p-5615400608001-brightcove-lonely-planets-best-destinations-to-visit-in-2018-20171028-052139.jpg?sharp=10&q=50&w=160&h=90"
+          qaHook={false}
         />
       </ThumbnailList>
     </StyleRoot>
@@ -2523,16 +2526,19 @@ storiesOf("Video components", module)
             title="List item 1"
             theme="dark"
             imagePath="https://lonelyplanetstatic.imgix.net/op-video-sync/images/production/p-5615400608001-brightcove-lonely-planets-best-destinations-to-visit-in-2018-20171028-052139.jpg?sharp=10&q=50&w=160&h=90"
+            qaHook={false}
           />
           <ThumbnailListItem
             title="List item 2"
             theme="dark"
             imagePath="https://lonelyplanetstatic.imgix.net/op-video-sync/images/production/p-5615400608001-brightcove-lonely-planets-best-destinations-to-visit-in-2018-20171028-052139.jpg?sharp=10&q=50&w=160&h=90"
+            qaHook={false}
           />
           <ThumbnailListItem
             title="List item 3"
             theme="dark"
             imagePath="https://lonelyplanetstatic.imgix.net/op-video-sync/images/production/p-5615400608001-brightcove-lonely-planets-best-destinations-to-visit-in-2018-20171028-052139.jpg?sharp=10&q=50&w=160&h=90"
+            qaHook={false}
           />
         </ThumbnailList>
       </div>
@@ -2554,6 +2560,7 @@ storiesOf("Video components", module)
         imageIcon={text("Image icon", "Play")}
         imageIconLabel={text("Image icon label", "Play")}
         theme={select("Theme", ["light", "dark", "active"], "light")}
+        qaHook={false}
       />
     </StyleRoot>
   ))
@@ -2929,6 +2936,7 @@ storiesOf("Video components", module)
         showFeaturedVideoCover={boolean("Show featured video cover", false)}
         mobile={boolean("Mobile", false)}
         onLoadVideo={(video, autoplay) => { console.log("onLoadVideo:", video, autoplay); }}
+        qaHook={boolean("QA Hook", false)}
         videos={[
           {
             id: "5615400608001",


### PR DESCRIPTION
`qaHook` is not valid (and ignored) on `react-router` Link objects and caused a warning in the console for dotcom-frontend. That has been fixed to handle via destructuring the `props` object being passed into our `Link` object that has a ternary that appends the external link `data-qa` hook properly or straight up ignores it. 

Additional QA hooks have been added to enhance testability in dotcom-frontend. All made optional inside backpack. 