### PR TITLE
fix: updated line height on breadcrumbs

### DIFF
--- a/src/components/breadcrumbs/index.jsx
+++ b/src/components/breadcrumbs/index.jsx
@@ -3,7 +3,11 @@ import PropTypes from "prop-types";
 import radium from "radium";
 import capitalize from "lodash/capitalize";
 import colors from "../../styles/colors";
-import { fontSizeBodySmall, fontWeightRegular } from "../../styles/typography";
+import {
+  fontSizeBodySmall,
+  fontWeightRegular,
+  lineHeightBodySmall,
+} from "../../styles/typography";
 import Icon from "../icon";
 import { blueLink } from "../../utils/mixins";
 import schema from "../../utils/schema";
@@ -20,7 +24,7 @@ const styles = {
     fontFamily: font("benton"),
     fontSize: `${fontSizeBodySmall}px`,
     fontWeight: fontWeightRegular,
-    lineHeight: 1,
+    lineHeight: lineHeightBodySmall,
   },
 
   item: {


### PR DESCRIPTION
Before:
<img width="599" alt="Screen Shot 2019-04-10 at 1 37 42 PM" src="https://user-images.githubusercontent.com/3586751/55902449-7c987180-5b99-11e9-8011-2d5c5950cee1.png">

After:
<img width="599" alt="Screen Shot 2019-04-10 at 1 37 52 PM" src="https://user-images.githubusercontent.com/3586751/55902460-828e5280-5b99-11e9-807b-58940653217e.png">
