### PR TITLE
fix: changed ShareSettings WhatsApp url for desktop

### DIFF
--- a/src/components/shareMenu/shareSettings.jsx
+++ b/src/components/shareMenu/shareSettings.jsx
@@ -48,6 +48,7 @@ class ShareSettings extends React.Component {
     const isFacebook = url.indexOf("facebook.com") !== -1;
     const isPinterest = url.indexOf("pinterest.com") !== -1;
     const isReddit = url.indexOf("reddit.com") !== -1;
+    const isWhatsApp = url.indexOf("whatsapp") !== -1;
     const isTwitter = url.indexOf("twitter.com") !== -1;
     const hasTwitterWidgets = typeof window !== "undefined" &&
       typeof window.__twttr !== "undefined" &&
@@ -56,6 +57,7 @@ class ShareSettings extends React.Component {
     const shouldOpenWindow = isFacebook ||
       isPinterest ||
       isReddit ||
+      isWhatsApp ||
       (isTwitter && !hasTwitterWidgets);
 
     if (shouldOpenWindow) {
@@ -108,6 +110,8 @@ class ShareSettings extends React.Component {
   }
 
   shareUrl() {
+    const { mobile } = this.props;
+
     const {
       url,
       text,
@@ -127,7 +131,10 @@ class ShareSettings extends React.Component {
       email: `mailto:?subject=${text}&body=${description}%0A%0A${url}`,
       pinterest: `https://www.pinterest.com/pin/create/button/?url=${url}&media=${image}&description=${description}`,
       reddit: `https://www.reddit.com/submit/?url=${url}`,
-      whatsapp: `whatsapp://send?text=${description}%0A%0A${url}`,
+      whatsapp: (mobile ?
+        `whatsapp://send?text=${description}%0A%0A${url}` :
+        `https://api.whatsapp.com/send?text=${description}%0A%0A${url}`
+      ),
       weChat: weChatQr,
     };
   }
@@ -145,6 +152,7 @@ class ShareSettings extends React.Component {
 
 ShareSettings.propTypes = {
   children: PropTypes.func.isRequired,
+  mobile: PropTypes.bool,
   handleClipboardSuccess: PropTypes.func,
   handleClipboardError: PropTypes.func,
   shareContent: PropTypes.shape({
@@ -159,6 +167,7 @@ ShareSettings.propTypes = {
 };
 
 ShareSettings.defaultProps = {
+  mobile: false,
   handleClipboardSuccess: () => null,
   handleClipboardError: () => null,
 };

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -1409,7 +1409,7 @@ storiesOf("Lockups", module)
   .addDecorator(withKnobs)
   .add("Accordion", () => (
     <StyleRoot>
-      <Accordion 
+      <Accordion
         id="storyAccordion"
         qaHook={text("Accordion QA Hook", "")}
       >
@@ -1726,6 +1726,7 @@ storiesOf("Lockups", module)
     <Center backgroundColor="white">
       <StyleRoot>
         <ShareSettings
+          mobile={boolean("Mobile", false)}
           shareContent={{
             text: "Animal islands: seven places where creatures rule",
             url: "https://www.lonelyplanet.com/asia/travel-tips-and-articles/animal-islands-seven-places-where-creatures-rule",


### PR DESCRIPTION
WhatsApp sharing through the `ShareSettings` component now uses `api.whatsapp` url to share when on non-mobile devices.  This is what the `VideoInfo` component already does and this is what the social share components in `rizzo-next` already do as well.

- Added `mobile` prop rather than using `MobileUtil.isMobile()` because that's how other backpack components work.
- WhatsApp sharing is now opened in new window now because before, it'd take the user off of LP.com whereas all the other social media urls open in a popup window or new tab.

**TESTING:**

**Desktop users with WhatsApp installed:**
1. Uses `api.whatsapp` url
2. Opens "send to whatsapp" popup
3. Opens WhatsApp desktop app.

**Desktop users without WhatsApp installed:**
1. Uses `api.whatsapp` url
2. Opens "send to whatsapp" popup
3. Opens WhatsApp web client in the same popup

**Mobile users without WhatsApp installed:**
1. Uses `whatsapp://` url
2. Browser shows error dialog:
![IMG_3266](https://user-images.githubusercontent.com/3586751/55991820-2a2e8200-5c79-11e9-959b-45be141d07d5.PNG)

**Mobile users with WhatsApp installed:**
1. Uses `whatsapp://` url
2. WhatsApp app is opened on users device.


**FOR ADDED KNOWLEDGE:**

If we use the `api.whatsapp` url on a mobile device that does NOT have WhatsApp installed, the user is taken to WhatsApp site and then presented the same error dialog they would have gotten with the `whatsapp://` url. -- So, basically if the user doesn't have WhatsApp app on their phone, they are screwed.

See:

![IMG_3267](https://user-images.githubusercontent.com/3586751/55992008-8691a180-5c79-11e9-9fde-14c2b67bb76e.PNG)

