### PR TITLE
feat: updated share urls for all networks under ShareSettings component

### DIFF
--- a/src/components/shareMenu/shareSettings.jsx
+++ b/src/components/shareMenu/shareSettings.jsx
@@ -48,7 +48,7 @@ class ShareSettings extends React.Component {
     const isFacebook = url.indexOf("facebook.com") !== -1;
     const isPinterest = url.indexOf("pinterest.com") !== -1;
     const isReddit = url.indexOf("reddit.com") !== -1;
-    const isWhatsApp = url.indexOf("whatsapp") !== -1;
+    const isWhatsApp = url.indexOf("whatsapp.com") !== -1;
     const isTwitter = url.indexOf("twitter.com") !== -1;
     const hasTwitterWidgets = typeof window !== "undefined" &&
       typeof window.__twttr !== "undefined" &&
@@ -110,8 +110,6 @@ class ShareSettings extends React.Component {
   }
 
   shareUrl() {
-    const { mobile } = this.props;
-
     const {
       url,
       text,
@@ -122,19 +120,18 @@ class ShareSettings extends React.Component {
       weChatQr,
     } = this.formattedShareContent();
 
+    const facebookAppId = "111537044496";
+
     const twitterText = twitterContent || `${description}&url=${url}&via=${via}`;
 
     return {
       twitter: `https://twitter.com/intent/tweet?text=${twitterText}`,
-      facebook: `https://www.facebook.com/sharer/sharer.php?u=${url}`,
-      facebookMessenger: `fb-messenger://share/?link=${url}`,
+      facebook: `https://www.facebook.com/dialog/share?app_id=${facebookAppId}&display=popup&href=${url}`,
+      facebookMessenger: `fb-messenger://share/?link=${url}&app_id=${facebookAppId}`,
       email: `mailto:?subject=${text}&body=${description}%0A%0A${url}`,
       pinterest: `https://www.pinterest.com/pin/create/button/?url=${url}&media=${image}&description=${description}`,
-      reddit: `https://www.reddit.com/submit/?url=${url}`,
-      whatsapp: (mobile ?
-        `whatsapp://send?text=${description}%0A%0A${url}` :
-        `https://api.whatsapp.com/send?text=${description}%0A%0A${url}`
-      ),
+      reddit: `https://www.reddit.com/submit/?url=${url}&title=${description}`,
+      whatsapp: `https://api.whatsapp.com/send?text=${description}%0A%0A${url}`,
       weChat: weChatQr,
     };
   }
@@ -152,7 +149,6 @@ class ShareSettings extends React.Component {
 
 ShareSettings.propTypes = {
   children: PropTypes.func.isRequired,
-  mobile: PropTypes.bool,
   handleClipboardSuccess: PropTypes.func,
   handleClipboardError: PropTypes.func,
   shareContent: PropTypes.shape({
@@ -167,7 +163,6 @@ ShareSettings.propTypes = {
 };
 
 ShareSettings.defaultProps = {
-  mobile: false,
   handleClipboardSuccess: () => null,
   handleClipboardError: () => null,
 };

--- a/stories/index.jsx
+++ b/stories/index.jsx
@@ -1726,7 +1726,6 @@ storiesOf("Lockups", module)
     <Center backgroundColor="white">
       <StyleRoot>
         <ShareSettings
-          mobile={boolean("Mobile", false)}
           shareContent={{
             text: "Animal islands: seven places where creatures rule",
             url: "https://www.lonelyplanet.com/asia/travel-tips-and-articles/animal-islands-seven-places-where-creatures-rule",


### PR DESCRIPTION
**WhatsApp:** Only uses the `api.whatsapp.com` url now as it works on both desktop and mobile, simplifying the component (no need for `mobile` prop).  It also has better UX for users on mobile who don't have the app installed.

**Reddit:** Now includes the share text along with the url

**Facebook:** Uses the documented share url here (https://developers.facebook.com/docs/sharing/reference/share-dialog) which allows us to pass in our facebook app id.

**Facebook Messenger:** Uses our facebook app id now