### PR TITLE
fix: use parentNode.removeChild() instead of remove() for IE 11

### DIFF
--- a/src/components/video/videoEmbed.jsx
+++ b/src/components/video/videoEmbed.jsx
@@ -799,7 +799,7 @@ class VideoEmbed extends Component {
 
   tearDownPlayer() {
     if (this.scriptElement) {
-      this.scriptElement.remove();
+      this.scriptElement.parentNode.removeChild(this.scriptElement);
       this.scriptElement = null;
     }
 


### PR DESCRIPTION
[`ChildNode.remove()`](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove#Browser_compatibility) doesn't work in IE11 so I've updated this to use `parentNode.removeChild()` instead.