### PR TITLE
fix: video recover from faulty ad setup

### DIFF
--- a/src/components/video/videoEmbed.jsx
+++ b/src/components/video/videoEmbed.jsx
@@ -463,6 +463,34 @@ class VideoEmbed extends Component {
   }
 
   onAdStarted() {
+    if (!this.isAdRunning()) {
+      /*
+        If an ads-ad-started event fired, but there is "no ad running",
+        it's an indication that something went wrong with the ad setup,
+        which most likely will put the player into a confused state.
+
+        Most commonly, you'll see `VIDEOJS: WARN: Unexpected startLinearAdMode invocation (Preroll)`
+        in your console just before the `ads-ad-started` event fires.
+
+        We only kill the ad from here if videojs-lp isn't being used because otherwise, videojs-lp
+        will handle it.
+
+        Read about the issue here:
+        https://github.com/googleads/videojs-ima/issues/796
+
+        Read about the ima3 method we use to kill the ad:
+        https://developers.google.com/interactive-media-ads/docs/sdks/android/v3/api/reference/com/google/ads/interactivemedia/v3/api/AdsManager.html#discardAdBreak()
+      */
+      if (!this.hasLPUIPlugin()) {
+        try {
+          this.player.ima3.adsManager.discardAdBreak();
+        } catch (e) {} /* eslint-disable-line no-empty */
+      }
+
+      // Act like onAdStarted never happened.
+      return;
+    }
+
     this.setState({
       playing: true,
     });


### PR DESCRIPTION
https://lonelyplanet.atlassian.net/browse/ENG-58

Summary: If a pre-roll attempts to play immediately following a previous pre-roll, there is sometimes a race condition issue that comes up that throws the player into a confused state:
 - Both the pre-roll and the video will play at the same time
 - You won't be able to see either of them
 - You'll be able to hear the video, while not being able to hear the pre-roll

The console will print something like this:
`VIDEOJS: WARN: Unexpected startLinearAdMode invocation (Preroll)`

I've only been able to reproduce this on Firefox.

This bug is in discussion here: https://github.com/googleads/videojs-ima/issues/796
But in short, 
```
The bug occurs when you try to load a pre-roll ad that takes more than the time specified in the prerollTimeout setting to load. ... This causes a WARN: 'Unexpected startLinearAdMode invocation (Preroll)', so this is an unexpected behavior for videojs-contrib-ads.
```

**Solution:** If `VideoEmbed` finds that an ad has started (via the `ads-ad-started` event, but it finds that `player.ads.state !== "ad-playback"`, it assumes that something went wrong and it instantly kills the ad using google's ima3 sdk directly (https://developers.google.com/interactive-media-ads/docs/sdks/android/v3/api/reference/com/google/ads/interactivemedia/v3/api/AdsManager.html#discardAdBreak())

This kills the ad and resume video playback as if nothing went wrong.

Almost identical code was ported to `videojs-lp` https://github.com/lonelyplanet/videojs-lp/pull/73 because it also needs to be aware of when ads come and go (or fail in this case), so that it knows how to render the player's UI.