### PR TITLE
fix: text area onFocus

### DIFF
--- a/src/components/form/textarea.jsx
+++ b/src/components/form/textarea.jsx
@@ -15,6 +15,8 @@ function TextArea(props) {
     theme,
     customStyles,
     qaHook,
+    onChange,
+    onFocus,
   } = props;
   const style = [styles.base];
 
@@ -42,6 +44,8 @@ function TextArea(props) {
       aria-label={label}
       qa-hook={qaHook ? createQAHook(name, id, "textarea") : null}
       title={label}
+      onChange={onChange}
+      onFocus={onFocus}
       {...sanitizedProps}
       style={style}
     />
@@ -75,6 +79,9 @@ TextArea.propTypes = {
 
   qaHook: PropTypes.bool,
 
+  onChange: PropTypes.func,
+
+  onFocus: PropTypes.func,
 };
 
 TextArea.defaultProps = {
@@ -97,6 +104,8 @@ TextArea.defaultProps = {
   theme: "base",
 
   onChange: null,
+
+  onFocus: null,
 
   qaHook: false,
 };

--- a/src/components/settingBlockTextArea/index.jsx
+++ b/src/components/settingBlockTextArea/index.jsx
@@ -5,7 +5,7 @@ import TextArea from "../form/textarea";
 import HeightExpander from "../form/heightExpander";
 
 const SettingBlockTextArea = (props) => {
-  const { onChange } = props;
+  const { onChange, onFocus } = props;
 
   return (
     <SettingBlock
@@ -18,6 +18,7 @@ const SettingBlockTextArea = (props) => {
         {(expandHeight, newHeight) => (
           <TextArea
             {...props}
+            onFocus={onFocus}
             id={props.id}
             onChange={(e) => {
               expandHeight(e);
@@ -48,6 +49,7 @@ SettingBlockTextArea.propTypes = {
   subtitle: PropTypes.string,
   error: PropTypes.bool,
   onChange: PropTypes.func,
+  onFocus: PropTypes.func,
 };
 
 export default SettingBlockTextArea;


### PR DESCRIPTION
see https://lonelyplanet.slack.com/archives/C026V0UT3/p1585150833000400
Hannah Horn reported:
"It seems that there might be a bug which is stopping users from being able to update their LP profile bio/intro - @john falkum and I tested this and we were also both unable to edit the Intro section. I can click in the box but when I try to type anything, it doesn't work :confused:. I am still able to edit and save a user's bio from within the auth/luna part of a user's profile."