### PR TITLE
fix: props not being passed to Link component when using relative url

### DIFF
--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -6,7 +6,7 @@ import { validReactAttributes } from "../../utils/validReactAttributes";
 
 const isExternal = (url) => /^(http|https):\/\//.test(url || "");
 
-const Link = ({ to, onClick, children, qaHook, className, ...rest }) => {
+const Link = ({ to, onClick, children, qaHook, ...rest }) => {
   const sanitizedProps = validReactAttributes(rest);
 
   return (
@@ -15,13 +15,16 @@ const Link = ({ to, onClick, children, qaHook, className, ...rest }) => {
         href={to}
         data-testid={qaHook ? createQAHook(`${qaHook}`, "external-link", "link") : null}
         onClick={onClick}
-        className={className}
         {...sanitizedProps}
       >
         {children}
       </a>
       :
-      <RouterLink to={to} onClick={onClick}>
+      <RouterLink
+        to={to}
+        onClick={onClick}
+        {...sanitizedProps}
+      >
         {children}
       </RouterLink>
   );


### PR DESCRIPTION
Problem was introduced here: 
https://github.com/lonelyplanet/backpack-ui/commit/ceada46f075787933343799f74902e80d233c25a#diff-9e7d4605239820b84fbe18a8dc471ad28e4c829b4ef712f22ce25802dfc638e3R18

React-router doc saying it's `Link` component handles standard props just fine: https://reactrouter.com/web/api/Link/others

The props for the `Link` component were using a spread to pass any remaining props into the underlying `a` tag, but only for internal links.

This created a problem because some components rely on styling the underlying `a` tag.  This was breaking padding and absolute positioning of children. 

Before (notice horizontal padding issue between image and text -- the image is wrapped in a `Link` component ):
<img width="1691" alt="Screen Shot 2021-04-15 at 12 09 59 PM" src="https://user-images.githubusercontent.com/3586751/114909313-0152a180-9deb-11eb-8b8a-6544d42e90b0.png">

After:
<img width="456" alt="Screen Shot 2021-04-15 at 12 56 55 PM" src="https://user-images.githubusercontent.com/3586751/114909384-162f3500-9deb-11eb-9550-f438785c25fd.png">


